### PR TITLE
#111 [fix] User 테이블 수정 및 fcmToken 중복 검사 로직 추가

### DIFF
--- a/src/main/java/hous/server/common/exception/ErrorCode.java
+++ b/src/main/java/hous/server/common/exception/ErrorCode.java
@@ -70,6 +70,7 @@ public enum ErrorCode {
     CONFLICT_EXCEPTION(CONFLICT, "이미 존재합니다."),
     CONFLICT_USER_EXCEPTION(CONFLICT, "이미 해당 계정으로 회원가입하셨습니다.\n로그인 해주세요."),
     CONFLICT_JOINED_ROOM_EXCEPTION(CONFLICT, "이미 참가중인 방이 있습니다."),
+    CONFLICT_FCM_TOKEN_EXCEPTION(CONFLICT, "fcm token 중복입니다."),
 
     /**
      * 415 Unsupported Media Type

--- a/src/main/java/hous/server/controller/auth/AuthController.java
+++ b/src/main/java/hous/server/controller/auth/AuthController.java
@@ -47,7 +47,11 @@ public class AuthController {
                             + "3. fcm token 을 입력해주세요.",
                     response = ErrorResponse.class),
             @ApiResponse(code = 401, message = "유효하지 않은 토큰입니다.", response = ErrorResponse.class),
-            @ApiResponse(code = 409, message = "이미 해당 계정으로 회원가입하셨습니다.\n로그인 해주세요.", response = ErrorResponse.class),
+            @ApiResponse(
+                    code = 409,
+                    message = "1. 이미 해당 계정으로 회원가입하셨습니다.\n   로그인 해주세요.\n"
+                            + "2. fcm token 중복입니다.",
+                    response = ErrorResponse.class),
             @ApiResponse(code = 500, message = "예상치 못한 서버 에러가 발생하였습니다.", response = ErrorResponse.class)
     })
     @PostMapping("/auth/login")

--- a/src/main/java/hous/server/domain/user/User.java
+++ b/src/main/java/hous/server/domain/user/User.java
@@ -19,7 +19,7 @@ public class User extends AuditingTimeEntity {
     @Embedded
     private SocialInfo socialInfo;
 
-    @Column(nullable = false, length = 300)
+    @Column(unique = true, length = 300)
     private String fcmToken;
 
     @Column(nullable = false, length = 30)
@@ -33,10 +33,9 @@ public class User extends AuditingTimeEntity {
     @JoinColumn(name = "setting_id", nullable = false)
     private Setting setting;
 
-    public static User newInstance(String socialId, UserSocialType socialType, String fcmToken, Setting setting) {
+    public static User newInstance(String socialId, UserSocialType socialType, Setting setting) {
         return User.builder()
                 .socialInfo(SocialInfo.of(socialId, socialType))
-                .fcmToken(fcmToken)
                 .setting(setting)
                 .status(UserStatus.ACTIVE)
                 .build();

--- a/src/main/java/hous/server/service/auth/impl/KaKaoAuthService.java
+++ b/src/main/java/hous/server/service/auth/impl/KaKaoAuthService.java
@@ -8,31 +8,34 @@ import hous.server.external.client.kakao.KakaoApiClient;
 import hous.server.external.client.kakao.dto.response.KakaoProfileResponse;
 import hous.server.service.auth.AuthService;
 import hous.server.service.auth.dto.request.LoginDto;
-import hous.server.service.firebase.FirebaseCloudMessageService;
 import hous.server.service.user.UserService;
 import hous.server.service.user.UserServiceUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
+@Transactional
 public class KaKaoAuthService implements AuthService {
 
     private static final UserSocialType socialType = UserSocialType.KAKAO;
 
     private final KakaoApiClient kaKaoApiCaller;
-    private final FirebaseCloudMessageService firebaseCloudMessageService;
 
+    private final UserRepository userRepository;
 
     private final UserService userService;
-    private final UserRepository userRepository;
 
     @Override
     public Long login(LoginDto request) {
         KakaoProfileResponse response = kaKaoApiCaller.getProfileInfo(HttpHeaderUtils.withBearerToken(request.getToken()));
         User user = UserServiceUtils.findUserBySocialIdAndSocialType(userRepository, response.getId(), socialType);
         if (user == null) return userService.registerUser(request.toCreateUserDto(response.getId()));
-        else user.updateFcmToken(request.getFcmToken());
+        else {
+            UserServiceUtils.validateUniqueFcmToken(userRepository, request.getFcmToken());
+            user.updateFcmToken(request.getFcmToken());
+        }
         return user.getId();
     }
 }

--- a/src/main/java/hous/server/service/user/UserService.java
+++ b/src/main/java/hous/server/service/user/UserService.java
@@ -52,12 +52,14 @@ public class UserService {
     public Long registerUser(CreateUserRequestDto request) {
         UserServiceUtils.validateNotExistsUser(userRepository, request.getSocialId(), request.getSocialType());
         User user = userRepository.save(User.newInstance(
-                request.getSocialId(), request.getSocialType(), request.getFcmToken(),
+                request.getSocialId(), request.getSocialType(),
                 settingRepository.save(Setting.newInstance())));
         Onboarding onboarding = onboardingRepository.save(Onboarding.newInstance(
                 user,
                 personalityRepository.findPersonalityByColor(PersonalityColor.GRAY),
                 testScoreRepository.save(TestScore.newInstance())));
+        UserServiceUtils.validateUniqueFcmToken(userRepository, request.getFcmToken());
+        user.updateFcmToken(request.getFcmToken());
         user.setOnboarding(onboarding);
         return user.getId();
     }

--- a/src/main/java/hous/server/service/user/UserServiceUtils.java
+++ b/src/main/java/hous/server/service/user/UserServiceUtils.java
@@ -37,6 +37,13 @@ public class UserServiceUtils {
         return user;
     }
 
+    public static void validateUniqueFcmToken(UserRepository userRepository, String fcmToken) {
+        User user = userRepository.findUserByFcmToken(fcmToken);
+        if (user != null) {
+            throw new ConflictException(String.format("fcm token (%s) 중복입니다.", fcmToken), CONFLICT_FCM_TOKEN_EXCEPTION);
+        }
+    }
+
     public static void validatePushSettingRequestStatus(UpdatePushSettingRequestDto request, User user) {
         if (request.isPushNotification() == user.getSetting().isPushNotification() &&
                 request.getRulesPushStatus() == user.getSetting().getRulesPushStatus() &&


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #111

## 🔑 Key Changes

1. User 테이블 fcmToken 칼럼 (nullable = true, unique = true) 로 수정
2. 회원가입, 로그인 로직 fcmToken 중복 검사 로직 추가

## 📢 To Reviewers
- 로그아웃시 fcmToken null 처리하는 로직은 로그아웃 관련 이슈 파서 따로 진행하겠습니당
