### PR TITLE
로그아웃 기능 구현

### DIFF
--- a/src/main/java/hous/server/controller/auth/AuthController.java
+++ b/src/main/java/hous/server/controller/auth/AuthController.java
@@ -79,6 +79,7 @@ public class AuthController {
                             + "2. refresh token 을 입력해주세요.",
                     response = ErrorResponse.class),
             @ApiResponse(code = 401, message = "토큰이 만료되었습니다. 다시 로그인 해주세요.", response = ErrorResponse.class),
+            @ApiResponse(code = 404, message = "탈퇴했거나 존재하지 않는 유저입니다.", response = ErrorResponse.class),
             @ApiResponse(code = 500, message = "예상치 못한 서버 에러가 발생하였습니다.", response = ErrorResponse.class)
     })
     @PostMapping("/auth/refresh")

--- a/src/main/java/hous/server/controller/rule/RuleController.java
+++ b/src/main/java/hous/server/controller/rule/RuleController.java
@@ -40,7 +40,7 @@ public class RuleController {
             @ApiResponse(
                     code = 404,
                     message = "1. 탈퇴했거나 존재하지 않는 유저입니다.\n"
-                            + "2. 존재하지 않는 방입니다.",
+                            + "2. 참가중인 방이 존재하지 않습니다.",
                     response = ErrorResponse.class),
             @ApiResponse(code = 500, message = "예상치 못한 서버 에러가 발생하였습니다.", response = ErrorResponse.class)
     })

--- a/src/main/java/hous/server/domain/user/User.java
+++ b/src/main/java/hous/server/domain/user/User.java
@@ -48,4 +48,8 @@ public class User extends AuditingTimeEntity {
     public void updateFcmToken(String fcmToken) {
         this.fcmToken = fcmToken;
     }
+
+    public void resetFcmToken() {
+        this.fcmToken = null;
+    }
 }

--- a/src/main/java/hous/server/service/auth/AuthServiceProvider.java
+++ b/src/main/java/hous/server/service/auth/AuthServiceProvider.java
@@ -2,7 +2,7 @@ package hous.server.service.auth;
 
 import hous.server.domain.user.UserSocialType;
 import hous.server.service.auth.impl.AppleAuthService;
-import hous.server.service.auth.impl.KaKaoAuthService;
+import hous.server.service.auth.impl.KakaoAuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -17,12 +17,12 @@ public class AuthServiceProvider {
     private static final Map<UserSocialType, AuthService> authServiceMap = new HashMap<>();
 
     private final AppleAuthService appleAuthService;
-    private final KaKaoAuthService kaKaoAuthService;
+    private final KakaoAuthService kakaoAuthService;
 
     @PostConstruct
     void initializeAuthServicesMap() {
         authServiceMap.put(UserSocialType.APPLE, appleAuthService);
-        authServiceMap.put(UserSocialType.KAKAO, kaKaoAuthService);
+        authServiceMap.put(UserSocialType.KAKAO, kakaoAuthService);
     }
 
     public AuthService getAuthService(UserSocialType socialType) {

--- a/src/main/java/hous/server/service/auth/CommonAuthService.java
+++ b/src/main/java/hous/server/service/auth/CommonAuthService.java
@@ -1,0 +1,27 @@
+package hous.server.service.auth;
+
+import hous.server.common.util.JwtUtils;
+import hous.server.domain.user.User;
+import hous.server.domain.user.repository.UserRepository;
+import hous.server.service.room.RoomServiceUtils;
+import hous.server.service.user.UserServiceUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class CommonAuthService {
+
+    private final UserRepository userRepository;
+
+    private final JwtUtils jwtProvider;
+
+    public void logout(Long userId) {
+        User user = UserServiceUtils.findUserById(userRepository, userId);
+        RoomServiceUtils.findParticipatingRoom(user);
+        jwtProvider.expireRefreshToken(user.getId());
+        user.resetFcmToken();
+    }
+}

--- a/src/main/java/hous/server/service/auth/CreateTokenService.java
+++ b/src/main/java/hous/server/service/auth/CreateTokenService.java
@@ -3,8 +3,11 @@ package hous.server.service.auth;
 import hous.server.common.exception.UnAuthorizedException;
 import hous.server.common.util.JwtUtils;
 import hous.server.domain.common.RedisKey;
+import hous.server.domain.user.User;
+import hous.server.domain.user.repository.UserRepository;
 import hous.server.service.auth.dto.request.TokenRequestDto;
 import hous.server.service.auth.dto.response.TokenResponse;
+import hous.server.service.user.UserServiceUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -15,6 +18,8 @@ import java.util.Objects;
 @RequiredArgsConstructor
 @Service
 public class CreateTokenService {
+
+    private final UserRepository userRepository;
 
     private final JwtUtils jwtProvider;
 
@@ -27,17 +32,21 @@ public class CreateTokenService {
 
     @Transactional
     public TokenResponse reissueToken(TokenRequestDto request) {
+        Long userId = jwtProvider.getUserIdFromJwt(request.getAccessToken());
+        User user = UserServiceUtils.findUserById(userRepository, userId);
         if (!jwtProvider.validateToken(request.getRefreshToken())) {
+            user.resetFcmToken();
             throw new UnAuthorizedException(String.format("주어진 리프레시 토큰 (%s) 이 유효하지 않습니다.", request.getRefreshToken()));
         }
-        Long userId = jwtProvider.getUserIdFromJwt(request.getAccessToken());
         String refreshToken = (String) redisTemplate.opsForValue().get(RedisKey.REFRESH_TOKEN + userId);
-
         if (Objects.isNull(refreshToken)) {
+            user.resetFcmToken();
             throw new UnAuthorizedException(String.format("이미 만료된 리프레시 토큰 (%s) 입니다.", request.getRefreshToken()));
         }
         if (!refreshToken.equals(request.getRefreshToken())) {
-            throw new UnAuthorizedException(String.format("해당 리프레시 토큰의 정보가 일치하지 않습니다.", request.getRefreshToken()));
+            jwtProvider.expireRefreshToken(user.getId());
+            user.resetFcmToken();
+            throw new UnAuthorizedException(String.format("해당 리프레시 토큰 (%s) 의 정보가 일치하지 않습니다.", request.getRefreshToken()));
         }
         return jwtProvider.createTokenInfo(userId);
     }

--- a/src/main/java/hous/server/service/auth/impl/KakaoAuthService.java
+++ b/src/main/java/hous/server/service/auth/impl/KakaoAuthService.java
@@ -17,11 +17,11 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Service
 @Transactional
-public class KaKaoAuthService implements AuthService {
+public class KakaoAuthService implements AuthService {
 
     private static final UserSocialType socialType = UserSocialType.KAKAO;
 
-    private final KakaoApiClient kaKaoApiCaller;
+    private final KakaoApiClient kakaoApiCaller;
 
     private final UserRepository userRepository;
 
@@ -29,7 +29,7 @@ public class KaKaoAuthService implements AuthService {
 
     @Override
     public Long login(LoginDto request) {
-        KakaoProfileResponse response = kaKaoApiCaller.getProfileInfo(HttpHeaderUtils.withBearerToken(request.getToken()));
+        KakaoProfileResponse response = kakaoApiCaller.getProfileInfo(HttpHeaderUtils.withBearerToken(request.getToken()));
         User user = UserServiceUtils.findUserBySocialIdAndSocialType(userRepository, response.getId(), socialType);
         if (user == null) return userService.registerUser(request.toCreateUserDto(response.getId()));
         else {

--- a/src/main/java/hous/server/service/firebase/FirebaseCloudMessageService.java
+++ b/src/main/java/hous/server/service/firebase/FirebaseCloudMessageService.java
@@ -42,6 +42,7 @@ public class FirebaseCloudMessageService {
             User user = userRepository.findUserByFcmToken(targetToken);
             if (user != null) {
                 jwtProvider.expireRefreshToken(user.getId());
+                user.resetFcmToken();
             }
             log.error(exception.getErrorMessage(), exception);
         }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #117 

## 🔑 Key Changes

1. 로그아웃 api 추가
2. 서비스 내부 로그아웃 로직에 fcmToken null 처리, refresh token 만료 처리 추가

## 📢 To Reviewers
- social 로그인별로 구별하기 위해 AuthServiceImpl 이 사용되고 있었는데 로그아웃은 공통처리라서 CommonAuthService 만들어서 처리했습니다.
- createTokenService 에서 이미 만료된 refreshToken 의 경우에는 fcmToken null 처리만 해줬습니다.
