### PR TITLE
호미 정렬, 슬랙 메시지 prod 환경에서만 오도록 수정

### DIFF
--- a/src/main/java/hous/server/domain/room/Participate.java
+++ b/src/main/java/hous/server/domain/room/Participate.java
@@ -45,7 +45,9 @@ public class Participate extends AuditingTimeEntity implements Comparable<Partic
             return -1;
         }
         if (t1 == null && t2 == null) {
-            return 0;
+            Participate p1 = getOnboarding().getParticipates().get(0);
+            Participate p2 = o.getOnboarding().getParticipates().get(0);
+            return p1.getCreatedAt().compareTo(p2.getCreatedAt());
         }
         return t1.getCreatedAt().compareTo(t2.getCreatedAt());
     }

--- a/src/main/java/hous/server/domain/room/Participate.java
+++ b/src/main/java/hous/server/domain/room/Participate.java
@@ -2,7 +2,9 @@ package hous.server.domain.room;
 
 import hous.server.domain.common.AuditingTimeEntity;
 import hous.server.domain.user.Onboarding;
+import hous.server.domain.user.TestScore;
 import lombok.*;
+import org.jetbrains.annotations.NotNull;
 
 import javax.persistence.*;
 
@@ -11,7 +13,7 @@ import javax.persistence.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)
-public class Participate extends AuditingTimeEntity {
+public class Participate extends AuditingTimeEntity implements Comparable<Participate> {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -30,5 +32,21 @@ public class Participate extends AuditingTimeEntity {
                 .onboarding(onboarding)
                 .room(room)
                 .build();
+    }
+
+    @Override
+    public int compareTo(@NotNull Participate o) {
+        TestScore t1 = getOnboarding().getTestScore();
+        TestScore t2 = o.getOnboarding().getTestScore();
+        if (t1 == null && t2 != null) {
+            return 1;
+        }
+        if (t1 != null && t2 == null) {
+            return -1;
+        }
+        if (t1 == null && t2 == null) {
+            return 0;
+        }
+        return t1.getCreatedAt().compareTo(t2.getCreatedAt());
     }
 }

--- a/src/main/java/hous/server/domain/user/Onboarding.java
+++ b/src/main/java/hous/server/domain/user/Onboarding.java
@@ -57,7 +57,7 @@ public class Onboarding extends AuditingTimeEntity {
     private Represent represent;
 
     @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "test_score_id", nullable = false)
+    @JoinColumn(name = "test_score_id")
     private TestScore testScore;
 
     @OneToMany(mappedBy = "onboarding", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
@@ -69,12 +69,10 @@ public class Onboarding extends AuditingTimeEntity {
     @OneToMany(mappedBy = "onboarding", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<Notification> notifications = new ArrayList<>();
 
-    public static Onboarding newInstance(User user, Personality personality, TestScore testScore,
-                                         String nickname, LocalDate birthday, boolean isPublic) {
+    public static Onboarding newInstance(User user, Personality personality, String nickname, LocalDate birthday, boolean isPublic) {
         return Onboarding.builder()
                 .user(user)
                 .personality(personality)
-                .testScore(testScore)
                 .nickname(nickname)
                 .birthday(birthday)
                 .isPublic(isPublic)
@@ -119,14 +117,11 @@ public class Onboarding extends AuditingTimeEntity {
         this.mbti = null;
         this.job = null;
         this.introduction = null;
+        this.testScore = null;
     }
 
     public void resetBadge() {
         this.represent = null;
         this.acquires.clear();
-    }
-
-    public void resetTestScore(TestScore testScore) {
-        this.testScore = testScore.resetScore(testScore);
     }
 }

--- a/src/main/java/hous/server/domain/user/Onboarding.java
+++ b/src/main/java/hous/server/domain/user/Onboarding.java
@@ -20,7 +20,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)
-public class Onboarding extends AuditingTimeEntity {
+public class Onboarding extends AuditingTimeEntity implements Comparable<Onboarding> {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -103,6 +103,10 @@ public class Onboarding extends AuditingTimeEntity {
         this.participates.remove(participate);
     }
 
+    public void setTestScore(TestScore testScore) {
+        this.testScore = testScore;
+    }
+
     public void updateUserInfo(UpdateUserInfoRequestDto request) {
         this.nickname = request.getNickname();
         this.isPublic = request.isPublic();
@@ -123,5 +127,21 @@ public class Onboarding extends AuditingTimeEntity {
     public void resetBadge() {
         this.represent = null;
         this.acquires.clear();
+    }
+
+    @Override
+    public int compareTo(Onboarding o) {
+        TestScore t1 = getTestScore();
+        TestScore t2 = o.getTestScore();
+        if (t1 == null && t2 != null) {
+            return 1;
+        }
+        if (t1 != null && t2 == null) {
+            return -1;
+        }
+        if (t1 == null && t2 == null) {
+            return 0;
+        }
+        return t1.getCreatedAt().compareTo(t2.getCreatedAt());
     }
 }

--- a/src/main/java/hous/server/domain/user/Onboarding.java
+++ b/src/main/java/hous/server/domain/user/Onboarding.java
@@ -140,7 +140,9 @@ public class Onboarding extends AuditingTimeEntity implements Comparable<Onboard
             return -1;
         }
         if (t1 == null && t2 == null) {
-            return 0;
+            Participate p1 = getParticipates().get(0);
+            Participate p2 = o.getParticipates().get(0);
+            return p1.getCreatedAt().compareTo(p2.getCreatedAt());
         }
         return t1.getCreatedAt().compareTo(t2.getCreatedAt());
     }

--- a/src/main/java/hous/server/domain/user/TestScore.java
+++ b/src/main/java/hous/server/domain/user/TestScore.java
@@ -49,11 +49,6 @@ public class TestScore extends AuditingTimeEntity {
         this.introversion = introversion;
     }
 
-    public TestScore resetScore(TestScore testScore) {
-        testScore.updateScore(0, 0, 0, 0, 0);
-        return testScore;
-    }
-
     public int getTotalTestScore() {
         return this.getLight() + this.getNoise() + this.getClean() + this.getSmell() + this.getIntroversion();
     }

--- a/src/main/java/hous/server/domain/user/TestScore.java
+++ b/src/main/java/hous/server/domain/user/TestScore.java
@@ -41,7 +41,7 @@ public class TestScore extends AuditingTimeEntity {
                 .build();
     }
 
-    public void updateScore(int light, int noise, int clean, int smell, int introversion) {
+    public void updateTestScore(int light, int noise, int clean, int smell, int introversion) {
         this.light = light;
         this.noise = noise;
         this.clean = clean;

--- a/src/main/java/hous/server/service/home/HomeRetrieveService.java
+++ b/src/main/java/hous/server/service/home/HomeRetrieveService.java
@@ -59,8 +59,9 @@ public class HomeRetrieveService {
         List<Rule> rules = room.getRules();
         List<Onboarding> participants = room.getParticipates().stream()
                 .map(Participate::getOnboarding)
-                .sorted(Comparator.comparing(onboarding -> onboarding.getTestScore().getUpdatedAt()))
+                .sorted(Onboarding::compareTo)
                 .collect(Collectors.toList());
-        return HomeInfoResponse.of(user.getOnboarding(), room, todayMyTodos, todayOurTodos, rules, participants);
+        List<Onboarding> meFirstList = UserServiceUtils.toMeFirstList(participants, user.getOnboarding());
+        return HomeInfoResponse.of(user.getOnboarding(), room, todayMyTodos, todayOurTodos, rules, meFirstList);
     }
 }

--- a/src/main/java/hous/server/service/room/RoomService.java
+++ b/src/main/java/hous/server/service/room/RoomService.java
@@ -14,6 +14,7 @@ import hous.server.domain.todo.repository.TakeRepository;
 import hous.server.domain.todo.repository.TodoRepository;
 import hous.server.domain.user.Onboarding;
 import hous.server.domain.user.User;
+import hous.server.domain.user.repository.TestScoreRepository;
 import hous.server.domain.user.repository.UserRepository;
 import hous.server.service.badge.BadgeService;
 import hous.server.service.room.dto.request.SetRoomNameRequestDto;
@@ -40,6 +41,7 @@ public class RoomService {
     private final DoneRepository doneRepository;
     private final AcquireRepository acquireRepository;
     private final RepresentRepository representRepository;
+    private final TestScoreRepository testScoreRepository;
     private final NotificationRepository notificationRepository;
 
     private final BadgeService badgeService;
@@ -102,9 +104,9 @@ public class RoomService {
         }
         acquireRepository.deleteAll(me.getAcquires());
         notificationRepository.deleteAll(me.getNotifications());
+        testScoreRepository.delete(me.getTestScore());
         me.resetUserInfo();
         me.resetBadge();
-        me.resetTestScore(me.getTestScore());
     }
 
     public boolean existsParticipatingRoomByUserId(Long userId) {

--- a/src/main/java/hous/server/service/slack/SlackService.java
+++ b/src/main/java/hous/server/service/slack/SlackService.java
@@ -23,6 +23,9 @@ import static com.slack.api.model.block.composition.BlockCompositions.markdownTe
 @Service
 @PropertySource(value = "classpath:application-slack.yml", factory = YamlPropertySourceFactory.class, ignoreResourceNotFound = true)
 public class SlackService {
+
+    @Value(value = "${spring.profiles.default}")
+    String profile;
     @Value(value = "${slack.token}")
     String token;
     @Value(value = "${slack.channel.monitor}")
@@ -35,15 +38,17 @@ public class SlackService {
     private static final String SLACK_ERROR_STACK = "*Error Stack:*\n";
 
     public void sendSlackMessage(Exception exception) {
-        try {
-            Slack slack = Slack.getInstance();
-            List<Attachment> attachments = createSlackAttachment(exception);
-            slack.methods(token).chatPostMessage(req ->
-                    req.channel(channel)
-                            .attachments(attachments)
-                            .text(SLACK_MESSAGE_TITLE));
-        } catch (SlackApiException | IOException e) {
-            log.error(e.getMessage(), e);
+        if (profile.equals("prod")) {
+            try {
+                Slack slack = Slack.getInstance();
+                List<Attachment> attachments = createSlackAttachment(exception);
+                slack.methods(token).chatPostMessage(req ->
+                        req.channel(channel)
+                                .attachments(attachments)
+                                .text(SLACK_MESSAGE_TITLE));
+            } catch (SlackApiException | IOException e) {
+                log.error(e.getMessage(), e);
+            }
         }
     }
 

--- a/src/main/java/hous/server/service/todo/TodoRetrieveService.java
+++ b/src/main/java/hous/server/service/todo/TodoRetrieveService.java
@@ -52,8 +52,16 @@ public class TodoRetrieveService {
         List<Todo> todos = room.getTodos();
         List<Todo> todayOurTodosList = TodoServiceUtils.filterDayOurTodos(today, todos);
         List<Todo> todayMyTodosList = TodoServiceUtils.filterDayMyTodos(today, user.getOnboarding(), todos);
-        List<TodoDetailInfo> todayMyTodos = todayMyTodosList.stream().sorted(Comparator.comparing(AuditingTimeEntity::getCreatedAt)).map(todo -> TodoDetailInfo.of(todo.getId(), todo.getName(), doneRepository.findTodayTodoCheckStatus(today, user.getOnboarding(), todo))).collect(Collectors.toList());
-        List<OurTodoInfo> todayOurTodos = todayOurTodosList.stream().sorted(Comparator.comparing(AuditingTimeEntity::getCreatedAt)).map(todo -> OurTodoInfo.of(todo.getName(), doneRepository.findTodayOurTodoStatus(today, todo), todo.getTakes().stream().map(take -> take.getOnboarding().getNickname()).collect(Collectors.toSet()))).collect(Collectors.toList());
+        List<TodoDetailInfo> todayMyTodos = todayMyTodosList.stream()
+                .sorted(Comparator.comparing(AuditingTimeEntity::getCreatedAt))
+                .map(todo -> TodoDetailInfo.of(todo.getId(), todo.getName(), doneRepository.findTodayTodoCheckStatus(today, user.getOnboarding(), todo)))
+                .collect(Collectors.toList());
+        List<OurTodoInfo> todayOurTodos = todayOurTodosList.stream()
+                .sorted(Comparator.comparing(AuditingTimeEntity::getCreatedAt))
+                .map(todo -> OurTodoInfo.of(todo.getName(), doneRepository.findTodayOurTodoStatus(today, todo), todo.getTakes().stream()
+                        .map(take -> take.getOnboarding().getNickname())
+                        .collect(Collectors.toSet())))
+                .collect(Collectors.toList());
         return TodoMainResponse.of(today, todayMyTodos, todayOurTodos);
     }
 

--- a/src/main/java/hous/server/service/todo/TodoRetrieveService.java
+++ b/src/main/java/hous/server/service/todo/TodoRetrieveService.java
@@ -6,6 +6,7 @@ import hous.server.domain.personality.PersonalityColor;
 import hous.server.domain.room.Participate;
 import hous.server.domain.room.Room;
 import hous.server.domain.todo.DayOfWeek;
+import hous.server.domain.todo.Take;
 import hous.server.domain.todo.Todo;
 import hous.server.domain.todo.repository.DoneRepository;
 import hous.server.domain.todo.repository.TodoRepository;
@@ -40,9 +41,10 @@ public class TodoRetrieveService {
         List<Participate> participates = room.getParticipates();
         List<Onboarding> onboardings = participates.stream()
                 .map(Participate::getOnboarding)
-                .sorted(Comparator.comparing(onboarding -> onboarding.getTestScore().getUpdatedAt()))
+                .sorted(Onboarding::compareTo)
                 .collect(Collectors.toList());
-        return UserPersonalityInfoResponse.of(onboardings);
+        List<Onboarding> meFirstList = UserServiceUtils.toMeFirstList(onboardings, user.getOnboarding());
+        return UserPersonalityInfoResponse.of(meFirstList);
     }
 
     public TodoMainResponse getTodoMain(Long userId) {
@@ -72,17 +74,28 @@ public class TodoRetrieveService {
         List<Participate> participates = room.getParticipates();
         List<Onboarding> onboardings = participates.stream()
                 .map(Participate::getOnboarding)
-                .sorted(Comparator.comparing(onboarding -> onboarding.getTestScore().getUpdatedAt()))
+                .sorted(Onboarding::compareTo)
                 .collect(Collectors.toList());
-        List<UserPersonalityInfo> userPersonalityInfos = TodoServiceUtils.toUserPersonalityInfoList(todo);
-        return TodoInfoResponse.of(todo, userPersonalityInfos, onboardings);
+        List<Onboarding> meFirstList = UserServiceUtils.toMeFirstList(onboardings, user.getOnboarding());
+        List<Onboarding> todoTakes = todo.getTakes().stream()
+                .map(Take::getOnboarding)
+                .sorted(Onboarding::compareTo)
+                .collect(Collectors.toList());
+        List<Onboarding> meFirstTodoTakes = UserServiceUtils.toMeFirstList(todoTakes, user.getOnboarding());
+        List<UserPersonalityInfo> userPersonalityInfos = TodoServiceUtils.toUserPersonalityInfoList(meFirstTodoTakes);
+        return TodoInfoResponse.of(todo, userPersonalityInfos, meFirstList);
     }
 
     public TodoSummaryInfoResponse getTodoSummaryInfo(Long todoId, Long userId) {
         User user = UserServiceUtils.findUserById(userRepository, userId);
         RoomServiceUtils.findParticipatingRoom(user);
         Todo todo = TodoServiceUtils.findTodoById(todoRepository, todoId);
-        List<UserPersonalityInfo> userPersonalityInfos = TodoServiceUtils.toUserPersonalityInfoList(todo);
+        List<Onboarding> todoTakes = todo.getTakes().stream()
+                .map(Take::getOnboarding)
+                .sorted(Onboarding::compareTo)
+                .collect(Collectors.toList());
+        List<Onboarding> meFirstTodoTakes = UserServiceUtils.toMeFirstList(todoTakes, user.getOnboarding());
+        List<UserPersonalityInfo> userPersonalityInfos = TodoServiceUtils.toUserPersonalityInfoList(meFirstTodoTakes);
         return TodoSummaryInfoResponse.of(todo, userPersonalityInfos, user.getOnboarding());
     }
 
@@ -126,33 +139,33 @@ public class TodoRetrieveService {
         List<TodoAllMemberResponse> otherMemberTodos = new ArrayList<>();
 
         // 성향테스트 참여 순서로 정렬
-        room.getParticipates().stream().sorted(
-                Comparator.comparing(participate -> participate.getOnboarding().getTestScore().getUpdatedAt())
-        ).forEach(participate -> {
-            List<Todo> memberTodos = TodoServiceUtils.filterAllDaysUserTodos(todos, participate.getOnboarding());
+        room.getParticipates().stream()
+                .sorted(Participate::compareTo)
+                .forEach(participate -> {
+                    List<Todo> memberTodos = TodoServiceUtils.filterAllDaysUserTodos(todos, participate.getOnboarding());
 
-            List<Todo>[] allDayMemberTodos = TodoServiceUtils.mapByDayOfWeekToList(memberTodos);
+                    List<Todo>[] allDayMemberTodos = TodoServiceUtils.mapByDayOfWeekToList(memberTodos);
 
-            List<DayOfWeekTodo> dayOfWeekTodos = new ArrayList<>();
-            int totalTodoCnt = 0;
-            for (int i = 1; i < allDayMemberTodos.length; i++) {
-                String dayOfWeek = DayOfWeek.getValueByIndex(i);
-                List<TodoInfo> thisDayTodosName = allDayMemberTodos[i].stream()
-                        .map(todo -> TodoInfo.of(todo.getId(), todo.getName()))
-                        .collect(Collectors.toList());
-                dayOfWeekTodos.add(DayOfWeekTodo.of(dayOfWeek, thisDayTodosName.size(), thisDayTodosName));
-                totalTodoCnt += thisDayTodosName.size();
-            }
+                    List<DayOfWeekTodo> dayOfWeekTodos = new ArrayList<>();
+                    int totalTodoCnt = 0;
+                    for (int i = 1; i < allDayMemberTodos.length; i++) {
+                        String dayOfWeek = DayOfWeek.getValueByIndex(i);
+                        List<TodoInfo> thisDayTodosName = allDayMemberTodos[i].stream()
+                                .map(todo -> TodoInfo.of(todo.getId(), todo.getName()))
+                                .collect(Collectors.toList());
+                        dayOfWeekTodos.add(DayOfWeekTodo.of(dayOfWeek, thisDayTodosName.size(), thisDayTodosName));
+                        totalTodoCnt += thisDayTodosName.size();
+                    }
 
-            String userName = participate.getOnboarding().getNickname();
-            PersonalityColor color = participate.getOnboarding().getPersonality().getColor();
+                    String userName = participate.getOnboarding().getNickname();
+                    PersonalityColor color = participate.getOnboarding().getPersonality().getColor();
 
-            if (user.getOnboarding().equals(participate.getOnboarding())) {
-                allMemberTodos.add(TodoAllMemberResponse.of(userName, color, totalTodoCnt, dayOfWeekTodos));
-            } else {
-                otherMemberTodos.add(TodoAllMemberResponse.of(userName, color, totalTodoCnt, dayOfWeekTodos));
-            }
-        });
+                    if (user.getOnboarding().equals(participate.getOnboarding())) {
+                        allMemberTodos.add(TodoAllMemberResponse.of(userName, color, totalTodoCnt, dayOfWeekTodos));
+                    } else {
+                        otherMemberTodos.add(TodoAllMemberResponse.of(userName, color, totalTodoCnt, dayOfWeekTodos));
+                    }
+                });
         allMemberTodos.addAll(otherMemberTodos);
 
         return allMemberTodos;

--- a/src/main/java/hous/server/service/todo/TodoServiceUtils.java
+++ b/src/main/java/hous/server/service/todo/TodoServiceUtils.java
@@ -17,7 +17,6 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -46,13 +45,12 @@ public class TodoServiceUtils {
         }
     }
 
-    public static List<UserPersonalityInfo> toUserPersonalityInfoList(Todo todo) {
-        return todo.getTakes().stream()
-                .sorted(Comparator.comparing(take -> take.getOnboarding().getTestScore().getUpdatedAt()))
-                .map(take -> UserPersonalityInfo.of(
-                        take.getOnboarding().getId(),
-                        take.getOnboarding().getPersonality().getColor(),
-                        take.getOnboarding().getNickname()))
+    public static List<UserPersonalityInfo> toUserPersonalityInfoList(List<Onboarding> onboardings) {
+        return onboardings.stream()
+                .map(onboarding -> UserPersonalityInfo.of(
+                        onboarding.getId(),
+                        onboarding.getPersonality().getColor(),
+                        onboarding.getNickname()))
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/hous/server/service/user/UserService.java
+++ b/src/main/java/hous/server/service/user/UserService.java
@@ -100,8 +100,9 @@ public class UserService {
         TestScore testScore = me.getTestScore();
         if (testScore == null) {
             testScore = testScoreRepository.save(TestScore.newInstance());
+            me.setTestScore(testScore);
         }
-        testScore.updateScore(request.getLight(), request.getNoise(), request.getClean(), request.getSmell(), request.getIntroversion());
+        testScore.updateTestScore(request.getLight(), request.getNoise(), request.getClean(), request.getSmell(), request.getIntroversion());
         Personality personality = UserServiceUtils.getPersonalityColorByTestScore(personalityRepository, testScore);
         me.updatePersonality(personality);
         badgeService.acquireBadge(user, BadgeInfo.I_AM_SUCH_A_PERSON);

--- a/src/main/java/hous/server/service/user/UserService.java
+++ b/src/main/java/hous/server/service/user/UserService.java
@@ -70,7 +70,6 @@ public class UserService {
         Onboarding onboarding = onboardingRepository.save(Onboarding.newInstance(
                 user,
                 personalityRepository.findPersonalityByColor(PersonalityColor.GRAY),
-                testScoreRepository.save(TestScore.newInstance()),
                 request.getNickname(),
                 request.getBirthday(),
                 request.getIsPublic()));
@@ -99,6 +98,9 @@ public class UserService {
         Room room = RoomServiceUtils.findParticipatingRoom(user);
         Onboarding me = user.getOnboarding();
         TestScore testScore = me.getTestScore();
+        if (testScore == null) {
+            testScore = testScoreRepository.save(TestScore.newInstance());
+        }
         testScore.updateScore(request.getLight(), request.getNoise(), request.getClean(), request.getSmell(), request.getIntroversion());
         Personality personality = UserServiceUtils.getPersonalityColorByTestScore(personalityRepository, testScore);
         me.updatePersonality(personality);

--- a/src/main/java/hous/server/service/user/UserServiceUtils.java
+++ b/src/main/java/hous/server/service/user/UserServiceUtils.java
@@ -6,6 +6,7 @@ import hous.server.common.exception.ValidationException;
 import hous.server.domain.personality.Personality;
 import hous.server.domain.personality.PersonalityColor;
 import hous.server.domain.personality.repository.PersonalityRepository;
+import hous.server.domain.user.Onboarding;
 import hous.server.domain.user.TestScore;
 import hous.server.domain.user.User;
 import hous.server.domain.user.UserSocialType;
@@ -13,6 +14,10 @@ import hous.server.domain.user.repository.UserRepository;
 import hous.server.service.user.dto.request.UpdatePushSettingRequestDto;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static hous.server.common.exception.ErrorCode.*;
 
@@ -115,4 +120,16 @@ public class UserServiceUtils {
         return null;
     }
 
+    public static List<Onboarding> toMeFirstList(List<Onboarding> onboardings, Onboarding me) {
+        List<Onboarding> result = new ArrayList<>();
+        List<Onboarding> justMeList = onboardings.stream()
+                .filter(onboarding -> onboarding.getId().equals(me.getId()))
+                .collect(Collectors.toList());
+        List<Onboarding> exceptMeList = onboardings.stream()
+                .filter(onboarding -> !onboarding.getId().equals(me.getId()))
+                .collect(Collectors.toList());
+        result.addAll(justMeList);
+        result.addAll(exceptMeList);
+        return result;
+    }
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #164

## 🔑 Key Changes

1. 성향 테스트에 한번이라도 참여한 사람들의 순서를 고정시키기 위해 인덱스를 추가하기보다는 createdAt 으로 비교하는게 맞다고 생각해서 다시 기존처럼 null 처리 하는 방식으로 수정했습니다.
2. 클래스에 Comparable implement 해서 성향테스트 참여한 사람은 앞으로, 안한 사람은 뒤로 정렬되도록 했고
3. 본인을 맨 앞으로 빼는 로직은 유틸화해서 처리했습니다!
4. 슬랙 메시지 관련해서 @Profile 은 관련 환경일 때만 Bean 으로 등록하게 하는 어노테이션인데 SlackService 를 ControllerExceptionAdvice 에서 사용중이라 @Value 사용해서 prod 환경일 때만 사용하도록 수정해뒀습니다!

## 📢 To Reviewers
- 와다다다 하긴 했는데.. 수정 필요한 부분이나 더 좋은 의견 제시해주세용 하핳
