### PR TITLE
성향 테스트 시 수정 성공 response와 함께 변경된 Personality color 전달하도록 수정

### DIFF
--- a/src/main/java/hous/server/common/success/SuccessCode.java
+++ b/src/main/java/hous/server/common/success/SuccessCode.java
@@ -48,6 +48,7 @@ public enum SuccessCode {
     // 성향
     GET_PERSONALITY_INFO_SUCCESS(OK, "성향 정보 조회 성공입니다."),
     GET_PERSONALITY_TEST_INFO_SUCCESS(OK, "성향테스트 정보 조회 성공입니다."),
+    UPDATE_PERSONALITY_TEST_SUCCESS(OK, "성향테스트 수정 성공입니다."),
 
     // 배지
     GET_BADGE_INFO_SUCCESS(OK, "나의 배지 목록 조회 성공입니다."),

--- a/src/main/java/hous/server/controller/user/UserController.java
+++ b/src/main/java/hous/server/controller/user/UserController.java
@@ -2,12 +2,14 @@ package hous.server.controller.user;
 
 import hous.server.common.dto.ErrorResponse;
 import hous.server.common.dto.SuccessResponse;
+import hous.server.common.success.SuccessCode;
 import hous.server.config.interceptor.Auth;
 import hous.server.config.resolver.UserId;
 import hous.server.service.user.UserService;
 import hous.server.service.user.dto.request.UpdatePushSettingRequestDto;
 import hous.server.service.user.dto.request.UpdateTestScoreRequestDto;
 import hous.server.service.user.dto.request.UpdateUserInfoRequestDto;
+import hous.server.service.user.dto.response.UpdatePersonalityColorResponse;
 import io.swagger.annotations.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -80,10 +82,10 @@ public class UserController {
 
     @ApiOperation(
             value = "[인증] 마이 페이지(Profile 뷰) - 성향테스트 결과 정보를 수정합니다.",
-            notes = "성향테스트 결과를 수정합니다."
+            notes = "성향테스트 결과를 후 변경된 성향테스트 색상을 전달합니다."
     )
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "성공입니다."),
+            @ApiResponse(code = 200, message = "성향테스트 수정 성공입니다."),
             @ApiResponse(
                     code = 400, message = "성향 테스트의 각 성향 점수는 최소 3점, 최대 9점입니다. (smell, light, noise, clean, introversion)", response = ErrorResponse.class),
             @ApiResponse(code = 401, message = "토큰이 만료되었습니다. 다시 로그인 해주세요.", response = ErrorResponse.class),
@@ -95,10 +97,9 @@ public class UserController {
     })
     @Auth
     @PutMapping("/user/personality")
-    public ResponseEntity<SuccessResponse<String>> updateUserTestScore(
+    public ResponseEntity<SuccessResponse<UpdatePersonalityColorResponse>> updateUserTestScore(
             @Valid @RequestBody UpdateTestScoreRequestDto request, @ApiIgnore @UserId Long userId) {
-        userService.updateUserTestScore(request, userId);
-        return SuccessResponse.OK;
+        return SuccessResponse.success(SuccessCode.UPDATE_PERSONALITY_TEST_SUCCESS, userService.updateUserTestScore(request, userId));
     }
 
     @ApiOperation(

--- a/src/main/java/hous/server/controller/user/UserController.java
+++ b/src/main/java/hous/server/controller/user/UserController.java
@@ -82,7 +82,7 @@ public class UserController {
 
     @ApiOperation(
             value = "[인증] 마이 페이지(Profile 뷰) - 성향테스트 결과 정보를 수정합니다.",
-            notes = "성향테스트 결과를 후 변경된 성향테스트 색상을 전달합니다."
+            notes = "성향테스트 결과를 수정 후 변경된 성향테스트 색상을 전달합니다."
     )
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "성향테스트 수정 성공입니다."),

--- a/src/main/java/hous/server/service/user/UserService.java
+++ b/src/main/java/hous/server/service/user/UserService.java
@@ -35,6 +35,7 @@ import hous.server.service.user.dto.request.CreateUserRequestDto;
 import hous.server.service.user.dto.request.UpdatePushSettingRequestDto;
 import hous.server.service.user.dto.request.UpdateTestScoreRequestDto;
 import hous.server.service.user.dto.request.UpdateUserInfoRequestDto;
+import hous.server.service.user.dto.response.UpdatePersonalityColorResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -102,7 +103,7 @@ public class UserService {
         setting.updatePushSetting(request);
     }
 
-    public void updateUserTestScore(UpdateTestScoreRequestDto request, Long userId) {
+    public UpdatePersonalityColorResponse updateUserTestScore(UpdateTestScoreRequestDto request, Long userId) {
         User user = UserServiceUtils.findUserById(userRepository, userId);
         Room room = RoomServiceUtils.findParticipatingRoom(user);
         Onboarding me = user.getOnboarding();
@@ -138,6 +139,7 @@ public class UserService {
                 badgeService.acquireBadge(onboarding.getUser(), BadgeInfo.OUR_HOUSE_HOMIES);
             });
         }
+        return UpdatePersonalityColorResponse.of(personality);
     }
 
     public void updateRepresentBadge(Long badgeId, Long userId) {

--- a/src/main/java/hous/server/service/user/UserServiceUtils.java
+++ b/src/main/java/hous/server/service/user/UserServiceUtils.java
@@ -108,7 +108,7 @@ public class UserServiceUtils {
         } else if (totalTestScore >= 40 && totalTestScore <= 45) {
             return personalityRepository.findPersonalityByColor(PersonalityColor.GREEN);
         }
-        return null;
+        return personalityRepository.findPersonalityByColor(PersonalityColor.GRAY);
     }
 
     public static List<Onboarding> toMeFirstList(List<Onboarding> onboardings, Onboarding me) {

--- a/src/main/java/hous/server/service/user/dto/response/UpdatePersonalityColorResponse.java
+++ b/src/main/java/hous/server/service/user/dto/response/UpdatePersonalityColorResponse.java
@@ -1,0 +1,21 @@
+package hous.server.service.user.dto.response;
+
+import hous.server.domain.personality.Personality;
+import hous.server.domain.personality.PersonalityColor;
+import lombok.*;
+
+@ToString
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class UpdatePersonalityColorResponse {
+
+    private PersonalityColor color;
+
+    public static UpdatePersonalityColorResponse of(Personality personality) {
+        return UpdatePersonalityColorResponse.builder()
+                .color(personality.getColor())
+                .build();
+    }
+}


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #185

## 🔑 Key Changes

1. 성향 테스트 시 수정 성공 response와 함께 변경된 Personality color 전달하도록 수정하였습니다.

## 📢 To Reviewers
- 기존에는 성향 테스트 시 새 값으로 변경까지만 했는데 color를 전달하도록 수정했습니다.
- 클라에서 테스트 후 바로 결과 화면을 보여줘야 하는데 그러려면 `GET /user/personality/test` 요청을 보내려면 color 값이 필요해서요!
   - 그런데 ... 지금 생각해보니 이렇게 되면 클라가 API 요청을 또 보내셔야 하는데 .... 
   - 뭔가 API 요청을 적게 보낼 수 있도록 return 시 특정 컬러의 결과 조회에 담기는 모든 값을 보내달라고 할 것 같기도 합니다만 ..... 어떻게 생각하시나요 ?! 그렇게 변경할까요 ... ?
-> _**클라와 얘기해봤는데 테스트 후 바로 결과창으로 넘어가는 flow가 맞다고 하여 변경된 personlity의 정보를 전달해주는 형태로 변경했습니다.**_

->**아요와 안드가 재논의한 결과 put따로 get 따로요청한다고 하여 color 값만 추가하겠습니다**