### PR TITLE
#193 [fix] 홈 화면 조회 요일 데이터 추가

### DIFF
--- a/src/main/java/hous/server/service/home/HomeRetrieveService.java
+++ b/src/main/java/hous/server/service/home/HomeRetrieveService.java
@@ -62,6 +62,6 @@ public class HomeRetrieveService {
                 .sorted(Onboarding::compareTo)
                 .collect(Collectors.toList());
         List<Onboarding> meFirstList = UserServiceUtils.toMeFirstList(participants, user.getOnboarding());
-        return HomeInfoResponse.of(user.getOnboarding(), room, todayMyTodos, todayOurTodos, rules, meFirstList);
+        return HomeInfoResponse.of(user.getOnboarding(), room, today, todayMyTodos, todayOurTodos, rules, meFirstList);
     }
 }

--- a/src/main/java/hous/server/service/home/dto/response/HomeInfoResponse.java
+++ b/src/main/java/hous/server/service/home/dto/response/HomeInfoResponse.java
@@ -1,5 +1,6 @@
 package hous.server.service.home.dto.response;
 
+import hous.server.common.util.DateUtils;
 import hous.server.common.util.MathUtils;
 import hous.server.domain.personality.PersonalityColor;
 import hous.server.domain.room.Room;
@@ -10,6 +11,7 @@ import hous.server.service.todo.dto.response.OurTodoInfo;
 import hous.server.service.todo.dto.response.TodoDetailInfo;
 import lombok.*;
 
+import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -24,6 +26,7 @@ public class HomeInfoResponse {
     private String userNickname;
     private String roomName;
     private String roomCode;
+    private String dayOfWeek;
     private int progress;
     private int myTodosCnt;
     private List<String> myTodos;
@@ -41,13 +44,14 @@ public class HomeInfoResponse {
         private PersonalityColor color;
     }
 
-    public static HomeInfoResponse of(Onboarding me, Room room, List<TodoDetailInfo> myTodos,
+    public static HomeInfoResponse of(Onboarding me, Room room, LocalDate today, List<TodoDetailInfo> myTodos,
                                       List<OurTodoInfo> ourTodos, List<Rule> rules, List<Onboarding> participants) {
         int doneOurTodosCnt = (int) ourTodos.stream().filter(ourTodo -> ourTodo.getStatus() == OurTodoStatus.FULL_CHECK).count();
         return HomeInfoResponse.builder()
                 .userNickname(me.getNickname())
                 .roomName(room.getName())
                 .roomCode(room.getCode())
+                .dayOfWeek(DateUtils.nowDayOfWeek(today))
                 .progress(MathUtils.percent(doneOurTodosCnt, ourTodos.size()))
                 .myTodosCnt(myTodos.size())
                 .myTodos(myTodos.stream()


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #193 

## 🔑 Key Changes

1. 홈 화면 조회 요일 데이터 추가

## 📢 To Reviewers
- 요일별 로티 띄워주기 위해 필요한 요일 데이터 추가했습니다!
