### PR TITLE
멤버별 조회 정렬 수정

### DIFF
--- a/src/main/java/hous/server/service/todo/TodoRetrieveService.java
+++ b/src/main/java/hous/server/service/todo/TodoRetrieveService.java
@@ -151,6 +151,7 @@ public class TodoRetrieveService {
                     for (int i = 1; i < allDayMemberTodos.length; i++) {
                         String dayOfWeek = DayOfWeek.getValueByIndex(i);
                         List<TodoInfo> thisDayTodosName = allDayMemberTodos[i].stream()
+                                .sorted(Comparator.comparing(AuditingTimeEntity::getCreatedAt))
                                 .map(todo -> TodoInfo.of(todo.getId(), todo.getName()))
                                 .collect(Collectors.toList());
                         dayOfWeekTodos.add(DayOfWeekTodo.of(dayOfWeek, thisDayTodosName.size(), thisDayTodosName));


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #208

## 🔑 Key Changes

1.멤버별 조회 시 각 멤버의 요일별 규칙 리스트의 정렬 순서를 규칙 생성 시점으로 정렬하도록 수정
![image](https://user-images.githubusercontent.com/68772751/200182007-e545dbb3-3329-4528-ac26-ea52f3c8fbd0.png)

