### PR TITLE
#220 [fix] 온보딩 introduction 필드 수정

### DIFF
--- a/src/main/java/hous/server/domain/user/Onboarding.java
+++ b/src/main/java/hous/server/domain/user/Onboarding.java
@@ -37,7 +37,7 @@ public class Onboarding extends AuditingTimeEntity implements Comparable<Onboard
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
     private LocalDate birthday;
 
-    @Column(length = 30)
+    @Column(length = 100)
     private String introduction;
 
     @Column(length = 30)


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #220

## 🔑 Key Changes

1. Onboarding 테이블의 introduction 의 최대 길이를 저희 정해놓은 컨벤션에 맞춰 40이 아니라 100으로 수정했답니다.
