### PR TITLE
[fix] 자기소개에서 \n 입력 시 공백으로 치환하여 저장하도록 수정

### DIFF
--- a/src/main/java/hous/server/controller/user/UserController.java
+++ b/src/main/java/hous/server/controller/user/UserController.java
@@ -29,7 +29,7 @@ public class UserController {
 
     @ApiOperation(
             value = "[인증] 마이 페이지(Profile 뷰) - 나의 프로필 정보를 수정합니다.",
-            notes = "프로필 정보 수정을 요청합니다."
+            notes = "프로필 정보 수정을 요청합니다. 자기소개에서 줄바꿈을 포함할 경우, ' '(공백)으로 변환하여 저장합니다."
     )
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "성공입니다."),

--- a/src/main/java/hous/server/controller/user/UserRetrieveController.java
+++ b/src/main/java/hous/server/controller/user/UserRetrieveController.java
@@ -34,7 +34,10 @@ public class UserRetrieveController {
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "나의 프로필 정보 조회 성공입니다."),
             @ApiResponse(code = 401, message = "토큰이 만료되었습니다. 다시 로그인 해주세요.", response = ErrorResponse.class),
-            @ApiResponse(code = 404, message = "탈퇴했거나 존재하지 않는 유저입니다.", response = ErrorResponse.class),
+            @ApiResponse(code = 404,
+                    message = "1. 탈퇴했거나 존재하지 않는 유저입니다.\n"
+                            + "2. 참가중인 방이 존재하지 않습니다.",
+                    response = ErrorResponse.class),
             @ApiResponse(code = 500, message = "예상치 못한 서버 에러가 발생하였습니다.", response = ErrorResponse.class)
     })
     @Auth

--- a/src/main/java/hous/server/domain/user/Onboarding.java
+++ b/src/main/java/hous/server/domain/user/Onboarding.java
@@ -113,7 +113,7 @@ public class Onboarding extends AuditingTimeEntity implements Comparable<Onboard
         this.birthday = request.getBirthday();
         this.mbti = request.getMbti();
         this.job = request.getJob();
-        this.introduction = request.getIntroduction();
+        this.introduction = request.getIntroduction().replaceAll("(\r\n|\r|\n|\n\r)", " ");
     }
 
     public void resetUserInfo() {


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #222

## 🔑 Key Changes

1. 사용자 정보 조회 시, 404 방에 참여하지 않음 예외가 빠져있어서 명세서에 추가했습니다.
2. 사용자 정보 수정 시, 자기소개에서 \n 입력 시 공백으로 치환하여 저장하도록 수정했습니다.
