### PR TITLE
#235 [fix] 멤버별 조회 시 todo Cnt 개수 수정

### DIFF
--- a/src/main/java/hous/server/controller/rule/RuleController.java
+++ b/src/main/java/hous/server/controller/rule/RuleController.java
@@ -67,8 +67,10 @@ public class RuleController {
             @ApiResponse(code = 200, message = "성공입니다."),
             @ApiResponse(
                     code = 400,
-                    message = "1. 규칙 리스트를 입력해주세요. (rules)\n"
-                            + "2. 규칙 리스트는 빈 배열을 보낼 수 없습니다. (rules)",
+                    message = "1. 규칙 내용을 입력해주세요.\n"
+                            + "2. 규칙은 20 글자 이내로 입력해주세요.\n"
+                            + "3. 규칙 리스트를 입력해주세요. (rules)\n"
+                            + "4. 규칙 리스트는 빈 배열을 보낼 수 없습니다. (rules)",
                     response = ErrorResponse.class),
             @ApiResponse(code = 401, message = "토큰이 만료되었습니다. 다시 로그인 해주세요.", response = ErrorResponse.class),
             @ApiResponse(

--- a/src/main/java/hous/server/service/rule/RuleService.java
+++ b/src/main/java/hous/server/service/rule/RuleService.java
@@ -78,6 +78,7 @@ public class RuleService {
         Room room = RoomServiceUtils.findParticipatingRoom(user);
         for (int idx = 0; idx < request.getRules().size(); idx++) {
             Rule rule = RuleServiceUtils.findRuleByIdAndRoom(ruleRepository, request.getRules().get(idx).getId(), room);
+            RuleServiceUtils.validateRuleName(room, request.getRules().get(idx).getName());
             rule.updateRule(request.getRules().get(idx).getName(), idx);
             room.updateRule(rule);
         }

--- a/src/main/java/hous/server/service/todo/TodoRetrieveService.java
+++ b/src/main/java/hous/server/service/todo/TodoRetrieveService.java
@@ -141,11 +141,11 @@ public class TodoRetrieveService {
                 .sorted(Participate::compareTo)
                 .forEach(participate -> {
                     List<Todo> memberTodos = TodoServiceUtils.filterAllDaysUserTodos(todos, participate.getOnboarding());
+                    List<Todo> memberUniqueTodos = TodoServiceUtils.filterAllDaysUserTodos(todos, participate.getOnboarding());
 
                     Map<Integer, Set<Todo>> allDayMemberTodos = TodoServiceUtils.mapByDayOfWeekToList(memberTodos);
 
                     List<DayOfWeekTodo> dayOfWeekTodos = new ArrayList<>();
-                    int totalTodoCnt = 0;
                     for (int day = DayOfWeek.MONDAY.getIndex(); day <= DayOfWeek.SUNDAY.getIndex(); day++) {
                         String dayOfWeek = DayOfWeek.getValueByIndex(day);
                         List<TodoInfo> thisDayTodosName = allDayMemberTodos.get(day).stream()
@@ -153,16 +153,15 @@ public class TodoRetrieveService {
                                 .map(todo -> TodoInfo.of(todo.getId(), todo.getName()))
                                 .collect(Collectors.toList());
                         dayOfWeekTodos.add(DayOfWeekTodo.of(dayOfWeek, thisDayTodosName.size(), thisDayTodosName));
-                        totalTodoCnt += thisDayTodosName.size();
                     }
 
                     String userName = participate.getOnboarding().getNickname();
                     PersonalityColor color = participate.getOnboarding().getPersonality().getColor();
 
                     if (user.getOnboarding().equals(participate.getOnboarding())) {
-                        allMemberTodos.add(TodoAllMemberResponse.of(userName, color, totalTodoCnt, dayOfWeekTodos));
+                        allMemberTodos.add(TodoAllMemberResponse.of(userName, color, memberUniqueTodos.size(), dayOfWeekTodos));
                     } else {
-                        otherMemberTodos.add(TodoAllMemberResponse.of(userName, color, totalTodoCnt, dayOfWeekTodos));
+                        otherMemberTodos.add(TodoAllMemberResponse.of(userName, color, memberUniqueTodos.size(), dayOfWeekTodos));
                     }
                 });
         allMemberTodos.addAll(otherMemberTodos);


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #235

## 🔑 Key Changes

1. 멤버별 조회 시 todo Cnt 개수 수정
  - 기존에는 멤버의 요일별 todo 수를 모두 더해  총 n개로 보내줬는데 해당 부분을 변경했습니다. 
  - 각 멤버가 맡은 todo 수를 총 n개로 보내주도록 수정했습니다.

## 📢 To Reviewers
![image](https://user-images.githubusercontent.com/68772751/204077913-fd58305e-179b-4471-a7aa-3f6d4056e882.png)
- 마지막 커밋만 봐주세용