### PR TITLE
#238 [fix] ourtodoinfo 가공 시 sorted(Onboarding::compareTo) 추가

### DIFF
--- a/src/main/java/hous/server/service/home/HomeRetrieveService.java
+++ b/src/main/java/hous/server/service/home/HomeRetrieveService.java
@@ -5,6 +5,7 @@ import hous.server.domain.common.AuditingTimeEntity;
 import hous.server.domain.room.Participate;
 import hous.server.domain.room.Room;
 import hous.server.domain.rule.Rule;
+import hous.server.domain.todo.Take;
 import hous.server.domain.todo.Todo;
 import hous.server.domain.todo.repository.DoneRepository;
 import hous.server.domain.user.Onboarding;
@@ -53,7 +54,7 @@ public class HomeRetrieveService {
                         todo.getName(),
                         doneRepository.findTodayOurTodoStatus(today, todo),
                         todo.getTakes().stream()
-                                .map(take -> take.getOnboarding().getNickname())
+                                .map(Take::getOnboarding)
                                 .collect(Collectors.toSet())))
                 .collect(Collectors.toList());
         List<Rule> rules = room.getRules();

--- a/src/main/java/hous/server/service/todo/TodoRetrieveService.java
+++ b/src/main/java/hous/server/service/todo/TodoRetrieveService.java
@@ -58,9 +58,10 @@ public class TodoRetrieveService {
                 .collect(Collectors.toList());
         List<OurTodoInfo> todayOurTodos = todayOurTodosList.stream()
                 .sorted(Comparator.comparing(AuditingTimeEntity::getCreatedAt))
-                .map(todo -> OurTodoInfo.of(todo.getName(), doneRepository.findTodayOurTodoStatus(today, todo), todo.getTakes().stream()
-                        .map(take -> take.getOnboarding().getNickname())
-                        .collect(Collectors.toSet())))
+                .map(todo -> OurTodoInfo.of(todo.getName(), doneRepository.findTodayOurTodoStatus(today, todo),
+                        todo.getTakes().stream()
+                                .map(Take::getOnboarding)
+                                .collect(Collectors.toSet())))
                 .collect(Collectors.toList());
         return TodoMainResponse.of(today, todayMyTodos, todayOurTodos);
     }

--- a/src/main/java/hous/server/service/todo/TodoRetrieveService.java
+++ b/src/main/java/hous/server/service/todo/TodoRetrieveService.java
@@ -47,21 +47,22 @@ public class TodoRetrieveService {
 
     public TodoMainResponse getTodoMain(Long userId) {
         User user = UserServiceUtils.findUserById(userRepository, userId);
+        Onboarding onboarding = user.getOnboarding();
         Room room = RoomServiceUtils.findParticipatingRoom(user);
         LocalDate today = DateUtils.todayLocalDate();
         List<Todo> todos = room.getTodos();
         List<Todo> todayOurTodosList = TodoServiceUtils.filterDayOurTodos(today, todos);
-        List<Todo> todayMyTodosList = TodoServiceUtils.filterDayMyTodos(today, user.getOnboarding(), todos);
+        List<Todo> todayMyTodosList = TodoServiceUtils.filterDayMyTodos(today, onboarding, todos);
         List<TodoDetailInfo> todayMyTodos = todayMyTodosList.stream()
                 .sorted(Comparator.comparing(AuditingTimeEntity::getCreatedAt))
-                .map(todo -> TodoDetailInfo.of(todo.getId(), todo.getName(), doneRepository.findTodayTodoCheckStatus(today, user.getOnboarding(), todo)))
+                .map(todo -> TodoDetailInfo.of(todo.getId(), todo.getName(), doneRepository.findTodayTodoCheckStatus(today, onboarding, todo)))
                 .collect(Collectors.toList());
         List<OurTodoInfo> todayOurTodos = todayOurTodosList.stream()
                 .sorted(Comparator.comparing(AuditingTimeEntity::getCreatedAt))
                 .map(todo -> OurTodoInfo.of(todo.getName(), doneRepository.findTodayOurTodoStatus(today, todo),
                         todo.getTakes().stream()
                                 .map(Take::getOnboarding)
-                                .collect(Collectors.toSet())))
+                                .collect(Collectors.toSet()), onboarding))
                 .collect(Collectors.toList());
         return TodoMainResponse.of(today, todayMyTodos, todayOurTodos);
     }
@@ -100,12 +101,13 @@ public class TodoRetrieveService {
 
     public List<TodoAllDayResponse> getTodoAllDayInfo(Long userId) {
         User user = UserServiceUtils.findUserById(userRepository, userId);
+        Onboarding onboarding = user.getOnboarding();
         Room room = RoomServiceUtils.findParticipatingRoom(user);
         List<Todo> todos = room.getTodos();
 
         // 이 방의 모든 요일의 todo list 조회
         List<Todo> ourTodosList = TodoServiceUtils.filterAllDaysOurTodos(todos);
-        List<Todo> myTodosList = TodoServiceUtils.filterAllDaysUserTodos(todos, user.getOnboarding());
+        List<Todo> myTodosList = TodoServiceUtils.filterAllDaysUserTodos(todos, onboarding);
 
         // 요일별(index) todo list 형태로 가공
         Map<Integer, Set<Todo>> allDayOurTodosList = TodoServiceUtils.mapByDayOfWeekToList(ourTodosList);
@@ -123,7 +125,7 @@ public class TodoRetrieveService {
                     .sorted(Comparator.comparing(AuditingTimeEntity::getCreatedAt))
                     .map(todo -> OurTodo.of(todo.getName(), todo.getTakes().stream()
                             .map(Take::getOnboarding)
-                            .collect(Collectors.toSet())))
+                            .collect(Collectors.toSet()), onboarding))
                     .collect(Collectors.toList());
             allDayTodosList.add(TodoAllDayResponse.of(dayOfWeek, todoInfos, ourTodoInfos));
         }

--- a/src/main/java/hous/server/service/todo/TodoRetrieveService.java
+++ b/src/main/java/hous/server/service/todo/TodoRetrieveService.java
@@ -121,7 +121,8 @@ public class TodoRetrieveService {
             List<OurTodo> ourTodoInfos = allDayOurTodosList.get(day).stream()
                     .sorted(Comparator.comparing(AuditingTimeEntity::getCreatedAt))
                     .map(todo -> OurTodo.of(todo.getName(), todo.getTakes().stream()
-                            .map(take -> take.getOnboarding().getNickname()).collect(Collectors.toSet())))
+                            .map(Take::getOnboarding)
+                            .collect(Collectors.toSet())))
                     .collect(Collectors.toList());
             allDayTodosList.add(TodoAllDayResponse.of(dayOfWeek, todoInfos, ourTodoInfos));
         }

--- a/src/main/java/hous/server/service/todo/dto/response/OurTodo.java
+++ b/src/main/java/hous/server/service/todo/dto/response/OurTodo.java
@@ -1,8 +1,11 @@
 package hous.server.service.todo.dto.response;
 
+import hous.server.domain.user.Onboarding;
 import lombok.*;
 
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @ToString
 @Getter
@@ -12,12 +15,15 @@ import java.util.Set;
 public class OurTodo {
 
     private String todoName;
-    private Set<String> nicknames;
+    private List<String> nicknames;
 
-    public static OurTodo of(String todoName, Set<String> nicknames) {
+    public static OurTodo of(String todoName, Set<Onboarding> onboardings) {
         return OurTodo.builder()
                 .todoName(todoName)
-                .nicknames(nicknames)
+                .nicknames(onboardings.stream()
+                        .sorted(Onboarding::compareTo)
+                        .map(Onboarding::getNickname)
+                        .collect(Collectors.toList()))
                 .build();
     }
 }

--- a/src/main/java/hous/server/service/todo/dto/response/OurTodo.java
+++ b/src/main/java/hous/server/service/todo/dto/response/OurTodo.java
@@ -1,6 +1,7 @@
 package hous.server.service.todo.dto.response;
 
 import hous.server.domain.user.Onboarding;
+import hous.server.service.user.UserServiceUtils;
 import lombok.*;
 
 import java.util.List;
@@ -17,11 +18,12 @@ public class OurTodo {
     private String todoName;
     private List<String> nicknames;
 
-    public static OurTodo of(String todoName, Set<Onboarding> onboardings) {
+    public static OurTodo of(String todoName, Set<Onboarding> onboardings, Onboarding me) {
+        List<Onboarding> sortByTestScore = onboardings.stream().sorted(Onboarding::compareTo).collect(Collectors.toList());
+        List<Onboarding> meFirstList = UserServiceUtils.toMeFirstList(sortByTestScore, me);
         return OurTodo.builder()
                 .todoName(todoName)
-                .nicknames(onboardings.stream()
-                        .sorted(Onboarding::compareTo)
+                .nicknames(meFirstList.stream()
                         .map(Onboarding::getNickname)
                         .collect(Collectors.toList()))
                 .build();

--- a/src/main/java/hous/server/service/todo/dto/response/OurTodoInfo.java
+++ b/src/main/java/hous/server/service/todo/dto/response/OurTodoInfo.java
@@ -2,6 +2,7 @@ package hous.server.service.todo.dto.response;
 
 import hous.server.domain.todo.OurTodoStatus;
 import hous.server.domain.user.Onboarding;
+import hous.server.service.user.UserServiceUtils;
 import lombok.*;
 
 import java.util.List;
@@ -21,12 +22,13 @@ public class OurTodoInfo extends OurTodo {
         this.status = status;
     }
 
-    public static OurTodoInfo of(String todoName, OurTodoStatus status, Set<Onboarding> onboardings) {
+    public static OurTodoInfo of(String todoName, OurTodoStatus status, Set<Onboarding> onboardings, Onboarding me) {
+        List<Onboarding> sortByTestScore = onboardings.stream().sorted(Onboarding::compareTo).collect(Collectors.toList());
+        List<Onboarding> meFirstList = UserServiceUtils.toMeFirstList(sortByTestScore, me);
         return OurTodoInfo.builder()
                 .todoName(todoName)
                 .status(status)
-                .nicknames(onboardings.stream()
-                        .sorted(Onboarding::compareTo)
+                .nicknames(meFirstList.stream()
                         .map(Onboarding::getNickname)
                         .collect(Collectors.toList()))
                 .build();

--- a/src/main/java/hous/server/service/todo/dto/response/OurTodoInfo.java
+++ b/src/main/java/hous/server/service/todo/dto/response/OurTodoInfo.java
@@ -1,9 +1,12 @@
 package hous.server.service.todo.dto.response;
 
 import hous.server.domain.todo.OurTodoStatus;
+import hous.server.domain.user.Onboarding;
 import lombok.*;
 
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @ToString
 @Getter
@@ -13,16 +16,19 @@ public class OurTodoInfo extends OurTodo {
     private OurTodoStatus status;
 
     @Builder(access = AccessLevel.PRIVATE)
-    public OurTodoInfo(String todoName, Set<String> nicknames, OurTodoStatus status) {
+    public OurTodoInfo(String todoName, List<String> nicknames, OurTodoStatus status) {
         super(todoName, nicknames);
         this.status = status;
     }
 
-    public static OurTodoInfo of(String todoName, OurTodoStatus status, Set<String> nicknames) {
+    public static OurTodoInfo of(String todoName, OurTodoStatus status, Set<Onboarding> onboardings) {
         return OurTodoInfo.builder()
                 .todoName(todoName)
                 .status(status)
-                .nicknames(nicknames)
+                .nicknames(onboardings.stream()
+                        .sorted(Onboarding::compareTo)
+                        .map(Onboarding::getNickname)
+                        .collect(Collectors.toList()))
                 .build();
     }
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #238

## 🔑 Key Changes

1. ourtodo 가공 시 기존에는 투두가 생성된 시간순으로만 정렬을 했었는데 이름에 정렬순서를 수정했습니다. 
