### PR TITLE
#240 [fix] 요일별 조회 시 OurTodo에 todoId를 넘겨주도록 수정

### DIFF
--- a/src/main/java/hous/server/service/home/HomeRetrieveService.java
+++ b/src/main/java/hous/server/service/home/HomeRetrieveService.java
@@ -51,9 +51,7 @@ public class HomeRetrieveService {
                 .collect(Collectors.toList());
         List<OurTodoInfo> todayOurTodos = todayOurTodosList.stream()
                 .sorted(Comparator.comparing(AuditingTimeEntity::getCreatedAt))
-                .map(todo -> OurTodoInfo.of(
-                        todo.getName(),
-                        doneRepository.findTodayOurTodoStatus(today, todo),
+                .map(todo -> OurTodoInfo.of(todo.getName(), doneRepository.findTodayOurTodoStatus(today, todo),
                         todo.getTakes().stream()
                                 .map(Take::getOnboarding)
                                 .collect(Collectors.toSet()),

--- a/src/main/java/hous/server/service/todo/TodoRetrieveService.java
+++ b/src/main/java/hous/server/service/todo/TodoRetrieveService.java
@@ -123,7 +123,7 @@ public class TodoRetrieveService {
                     .collect(Collectors.toList());
             List<OurTodo> ourTodoInfos = allDayOurTodosList.get(day).stream()
                     .sorted(Comparator.comparing(AuditingTimeEntity::getCreatedAt))
-                    .map(todo -> OurTodo.of(todo.getName(), todo.getTakes().stream()
+                    .map(todo -> OurTodo.of(todo.getId(), todo.getName(), todo.getTakes().stream()
                             .map(Take::getOnboarding)
                             .collect(Collectors.toSet()), onboarding))
                     .collect(Collectors.toList());

--- a/src/main/java/hous/server/service/todo/dto/response/OurTodo.java
+++ b/src/main/java/hous/server/service/todo/dto/response/OurTodo.java
@@ -15,13 +15,15 @@ import java.util.stream.Collectors;
 @Builder(access = AccessLevel.PRIVATE)
 public class OurTodo {
 
+    private Long todoId;
     private String todoName;
     private List<String> nicknames;
 
-    public static OurTodo of(String todoName, Set<Onboarding> onboardings, Onboarding me) {
+    public static OurTodo of(Long todoId, String todoName, Set<Onboarding> onboardings, Onboarding me) {
         List<Onboarding> sortByTestScore = onboardings.stream().sorted(Onboarding::compareTo).collect(Collectors.toList());
         List<Onboarding> meFirstList = UserServiceUtils.toMeFirstList(sortByTestScore, me);
         return OurTodo.builder()
+                .todoId(todoId)
                 .todoName(todoName)
                 .nicknames(meFirstList.stream()
                         .map(Onboarding::getNickname)

--- a/src/main/java/hous/server/service/todo/dto/response/OurTodoInfo.java
+++ b/src/main/java/hous/server/service/todo/dto/response/OurTodoInfo.java
@@ -12,15 +12,13 @@ import java.util.stream.Collectors;
 @ToString
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class OurTodoInfo extends OurTodo {
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class OurTodoInfo {
 
+    private String todoName;
+    List<String> nicknames;
     private OurTodoStatus status;
-
-    @Builder(access = AccessLevel.PRIVATE)
-    public OurTodoInfo(String todoName, List<String> nicknames, OurTodoStatus status) {
-        super(todoName, nicknames);
-        this.status = status;
-    }
 
     public static OurTodoInfo of(String todoName, OurTodoStatus status, Set<Onboarding> onboardings, Onboarding me) {
         List<Onboarding> sortByTestScore = onboardings.stream().sorted(Onboarding::compareTo).collect(Collectors.toList());


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #240

## 🔑 Key Changes

1. 요일별 조회 시 OurTodo에 todoId를 넘겨주도록 수정
2. OurTodoInfo extends OurTodo 상속하던거 제거
