### PR TITLE
규칙, todo 추가/수정 시 이미 존재하는 name인 경우 409를 던지도록 수정

### DIFF
--- a/src/main/java/hous/server/common/exception/ErrorCode.java
+++ b/src/main/java/hous/server/common/exception/ErrorCode.java
@@ -76,6 +76,7 @@ public enum ErrorCode {
     CONFLICT_LOGIN_EXCEPTION(CONFLICT, "이미 로그인 중인 유저입니다."),
     CONFLICT_JOINED_ROOM_EXCEPTION(CONFLICT, "이미 참가중인 방이 있습니다."),
     CONFLICT_RULE_EXCEPTION(CONFLICT, "이미 존재하는 규칙입니다."),
+    CONFLICT_TODO_EXCEPTION(CONFLICT, "이미 존재하는 todo 입니다."),
 
     /**
      * 415 Unsupported Media Type

--- a/src/main/java/hous/server/common/exception/ErrorCode.java
+++ b/src/main/java/hous/server/common/exception/ErrorCode.java
@@ -1,21 +1,10 @@
 package hous.server.common.exception;
 
-import static hous.server.common.exception.ErrorStatusCode.BAD_GATEWAY;
-import static hous.server.common.exception.ErrorStatusCode.BAD_REQUEST;
-import static hous.server.common.exception.ErrorStatusCode.CONFLICT;
-import static hous.server.common.exception.ErrorStatusCode.FORBIDDEN;
-import static hous.server.common.exception.ErrorStatusCode.INTERNAL_SERVER;
-import static hous.server.common.exception.ErrorStatusCode.METHOD_NOT_ALLOWED;
-import static hous.server.common.exception.ErrorStatusCode.NOT_ACCEPTABLE;
-import static hous.server.common.exception.ErrorStatusCode.NOT_FOUND;
-import static hous.server.common.exception.ErrorStatusCode.SERVICE_UNAVAILABLE;
-import static hous.server.common.exception.ErrorStatusCode.UNAUTHORIZED;
-import static hous.server.common.exception.ErrorStatusCode.UNSUPPORTED_MEDIA_TYPE;
-import static hous.server.common.exception.ErrorStatusCode.UPGRADE_REQUIRED;
-
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import static hous.server.common.exception.ErrorStatusCode.*;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
@@ -86,6 +75,7 @@ public enum ErrorCode {
     CONFLICT_USER_EXCEPTION(CONFLICT, "이미 해당 계정으로 회원가입하셨습니다.\n로그인 해주세요."),
     CONFLICT_LOGIN_EXCEPTION(CONFLICT, "이미 로그인 중인 유저입니다."),
     CONFLICT_JOINED_ROOM_EXCEPTION(CONFLICT, "이미 참가중인 방이 있습니다."),
+    CONFLICT_RULE_EXCEPTION(CONFLICT, "이미 존재하는 규칙입니다."),
 
     /**
      * 415 Unsupported Media Type

--- a/src/main/java/hous/server/controller/rule/RuleController.java
+++ b/src/main/java/hous/server/controller/rule/RuleController.java
@@ -48,6 +48,7 @@ public class RuleController {
                     message = "1. 탈퇴했거나 존재하지 않는 유저입니다.\n"
                             + "2. 참가중인 방이 존재하지 않습니다.",
                     response = ErrorResponse.class),
+            @ApiResponse(code = 409, message = "이미 존재하는 규칙입니다.", response = ErrorResponse.class),
             @ApiResponse(code = 500, message = "예상치 못한 서버 에러가 발생하였습니다.", response = ErrorResponse.class)
     })
     @Auth
@@ -79,6 +80,7 @@ public class RuleController {
                             + "2. 존재하지 않는 방입니다.\n"
                             + "3. 존재하지 않는 규칙입니다.",
                     response = ErrorResponse.class),
+            @ApiResponse(code = 409, message = "이미 존재하는 규칙입니다.", response = ErrorResponse.class),
             @ApiResponse(code = 500, message = "예상치 못한 서버 에러가 발생하였습니다.", response = ErrorResponse.class)
     })
     @Auth

--- a/src/main/java/hous/server/controller/todo/TodoController.java
+++ b/src/main/java/hous/server/controller/todo/TodoController.java
@@ -46,6 +46,7 @@ public class TodoController {
                             + "2. 참가중인 방이 존재하지 않습니다.\n"
                             + "3. 유저의 온보딩 정보가 존재하지 않습니다.",
                     response = ErrorResponse.class),
+            @ApiResponse(code = 409, message = "이미 존재하는 todo 입니다.", response = ErrorResponse.class),
             @ApiResponse(code = 500, message = "예상치 못한 서버 에러가 발생하였습니다.", response = ErrorResponse.class)
     })
     @Auth
@@ -78,6 +79,7 @@ public class TodoController {
                             + "3. 유저의 온보딩 정보가 존재하지 않습니다.\n"
                             + "4. 존재하지 않는 todo 입니다.",
                     response = ErrorResponse.class),
+            @ApiResponse(code = 409, message = "이미 존재하는 todo 입니다.", response = ErrorResponse.class),
             @ApiResponse(code = 500, message = "예상치 못한 서버 에러가 발생하였습니다.", response = ErrorResponse.class)
     })
     @Auth

--- a/src/main/java/hous/server/service/rule/RuleService.java
+++ b/src/main/java/hous/server/service/rule/RuleService.java
@@ -17,6 +17,7 @@ import hous.server.service.room.RoomServiceUtils;
 import hous.server.service.rule.dto.request.CreateRuleRequestDto;
 import hous.server.service.rule.dto.request.DeleteRuleReqeustDto;
 import hous.server.service.rule.dto.request.UpdateRuleRequestDto;
+import hous.server.service.rule.dto.response.RuleInfo;
 import hous.server.service.user.UserServiceUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -47,6 +48,7 @@ public class RuleService {
         Onboarding me = user.getOnboarding();
         Room room = RoomServiceUtils.findParticipatingRoom(user);
         RuleServiceUtils.validateRuleCounts(room, request.getRuleNames().size());
+        RuleServiceUtils.existsRuleByRoomRules(room, request.getRuleNames());
         AtomicInteger ruleIdx = new AtomicInteger(RuleServiceUtils.findRuleIdxByRoomId(ruleRepository, room));
         List<Rule> rules = request.getRuleNames().stream()
                 .map(ruleName -> {
@@ -76,6 +78,7 @@ public class RuleService {
     public void updateRules(UpdateRuleRequestDto request, Long userId) {
         User user = UserServiceUtils.findUserById(userRepository, userId);
         Room room = RoomServiceUtils.findParticipatingRoom(user);
+        RuleServiceUtils.existsRuleByRoomRules(room, request.getRules().stream().map(RuleInfo::getName).collect(Collectors.toList()));
         for (int idx = 0; idx < request.getRules().size(); idx++) {
             Rule rule = RuleServiceUtils.findRuleByIdAndRoom(ruleRepository, request.getRules().get(idx).getId(), room);
             RuleServiceUtils.validateRuleName(room, request.getRules().get(idx).getName());

--- a/src/main/java/hous/server/service/rule/RuleServiceUtils.java
+++ b/src/main/java/hous/server/service/rule/RuleServiceUtils.java
@@ -1,5 +1,6 @@
 package hous.server.service.rule;
 
+import hous.server.common.exception.ConflictException;
 import hous.server.common.exception.ForbiddenException;
 import hous.server.common.exception.NotFoundException;
 import hous.server.common.exception.ValidationException;
@@ -9,6 +10,9 @@ import hous.server.domain.rule.Rule;
 import hous.server.domain.rule.repository.RuleRepository;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static hous.server.common.exception.ErrorCode.*;
 
@@ -43,5 +47,14 @@ public class RuleServiceUtils {
             throw new NotFoundException(String.format("존재하지 않는 규칙 (%s) 입니다", ruleId), NOT_FOUND_RULE_EXCEPTION);
         }
         return rule;
+    }
+
+    public static void existsRuleByRoomRules(Room room, List<String> requestRules) {
+        List<String> rules = room.getRules().stream().map(Rule::getName).collect(Collectors.toList());
+        for (String ruleName : requestRules) {
+            if (rules.contains(ruleName)) {
+                throw new ConflictException(String.format("방 (%s) 에 이미 존재하는 todo (%s) 입니다.", room.getId(), ruleName), CONFLICT_RULE_EXCEPTION);
+            }
+        }
     }
 }

--- a/src/main/java/hous/server/service/todo/TodoService.java
+++ b/src/main/java/hous/server/service/todo/TodoService.java
@@ -48,6 +48,7 @@ public class TodoService {
         User user = UserServiceUtils.findUserById(userRepository, userId);
         Room room = RoomServiceUtils.findParticipatingRoom(user);
         TodoServiceUtils.validateTodoCounts(room);
+        TodoServiceUtils.existsTodoByRoomTodos(room, request.getName());
         Todo todo = todoRepository.save(Todo.newInstance(room, request.getName(), request.isPushNotification()));
         request.getTodoUsers().forEach(todoUser -> {
             Onboarding onboarding = UserServiceUtils.findOnboardingById(onboardingRepository, todoUser.getOnboardingId());
@@ -72,6 +73,7 @@ public class TodoService {
     public void updateTodo(Long todoId, TodoInfoRequestDto request) {
         Todo todo = TodoServiceUtils.findTodoById(todoRepository, todoId);
         Room room = todo.getRoom();
+        TodoServiceUtils.existsTodoByRoomTodos(room, request.getName());
         todo.getTakes().forEach(take -> {
             redoRepository.deleteAll(take.getRedos());
             takeRepository.delete(take);

--- a/src/main/java/hous/server/service/todo/TodoServiceUtils.java
+++ b/src/main/java/hous/server/service/todo/TodoServiceUtils.java
@@ -1,5 +1,6 @@
 package hous.server.service.todo;
 
+import hous.server.common.exception.ConflictException;
 import hous.server.common.exception.ForbiddenException;
 import hous.server.common.exception.NotFoundException;
 import hous.server.common.exception.ValidationException;
@@ -42,6 +43,13 @@ public class TodoServiceUtils {
     public static void validateTodoStatus(DoneRepository doneRepository, boolean status, Onboarding onboarding, Todo todo) {
         if (status == doneRepository.findTodayTodoCheckStatus(DateUtils.todayLocalDate(), onboarding, todo)) {
             throw new ValidationException(String.format("(%s) 유저의 todo (%s) 상태는 이미 (%s) 입니다.", onboarding.getId(), todo.getId(), status), VALIDATION_STATUS_EXCEPTION);
+        }
+    }
+
+    public static void existsTodoByRoomTodos(Room room, String requestTodo) {
+        List<String> todos = room.getTodos().stream().map(Todo::getName).collect(Collectors.toList());
+        if (todos.contains(requestTodo)) {
+            throw new ConflictException(String.format("방 (%s) 에 이미 존재하는 todo (%s) 입니다.", room.getId(), requestTodo), CONFLICT_TODO_EXCEPTION);
         }
     }
 


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #244

## 🔑 Key Changes

1. 규칙 추가/수정 시 이미 존재하는 name인 경우 409를 던지도록 utils 함수 추가 및 API 명세서 수정
2. todo 추가/수정 시 이미 존재하는 name인 경우 409를 던지도록 utils 함수 추가 및 API 명세서 수정

