### PR TITLE
#254 [fix] todo 수정시 수정하는 todo 제외하고 이름 검사하도록 수정

### DIFF
--- a/src/main/java/hous/server/service/todo/TodoService.java
+++ b/src/main/java/hous/server/service/todo/TodoService.java
@@ -48,7 +48,7 @@ public class TodoService {
         User user = UserServiceUtils.findUserById(userRepository, userId);
         Room room = RoomServiceUtils.findParticipatingRoom(user);
         TodoServiceUtils.validateTodoCounts(room);
-        TodoServiceUtils.existsTodoByRoomTodos(room, request.getName());
+        TodoServiceUtils.existsTodoByRoomTodos(room, request.getName(), null);
         Todo todo = todoRepository.save(Todo.newInstance(room, request.getName(), request.isPushNotification()));
         request.getTodoUsers().forEach(todoUser -> {
             Onboarding onboarding = UserServiceUtils.findOnboardingById(onboardingRepository, todoUser.getOnboardingId());
@@ -74,7 +74,7 @@ public class TodoService {
         UserServiceUtils.findUserById(userRepository, userId);
         Todo todo = TodoServiceUtils.findTodoById(todoRepository, todoId);
         Room room = todo.getRoom();
-        TodoServiceUtils.existsTodoByRoomTodos(room, request.getName());
+        TodoServiceUtils.existsTodoByRoomTodos(room, request.getName(), todo);
         todo.getTakes().forEach(take -> {
             redoRepository.deleteAll(take.getRedos());
             takeRepository.delete(take);

--- a/src/main/java/hous/server/service/todo/TodoServiceUtils.java
+++ b/src/main/java/hous/server/service/todo/TodoServiceUtils.java
@@ -46,8 +46,11 @@ public class TodoServiceUtils {
         }
     }
 
-    public static void existsTodoByRoomTodos(Room room, String requestTodo) {
+    public static void existsTodoByRoomTodos(Room room, String requestTodo, Todo todo) {
         List<String> todos = room.getTodos().stream().map(Todo::getName).collect(Collectors.toList());
+        if (todo != null) {
+            todos.remove(todo.getName());
+        }
         if (todos.contains(requestTodo)) {
             throw new ConflictException(String.format("방 (%s) 에 이미 존재하는 todo (%s) 입니다.", room.getId(), requestTodo), CONFLICT_TODO_EXCEPTION);
         }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #254

## 🔑 Key Changes

1. todo 수정시 수정하는 todo 제외하고 이름 검사하도록 수정

