### PR TITLE
#258 [feat] 강제 업데이트 관련 api 구현

### DIFF
--- a/src/main/java/hous/server/common/success/SuccessCode.java
+++ b/src/main/java/hous/server/common/success/SuccessCode.java
@@ -16,6 +16,9 @@ public enum SuccessCode {
      */
     OK_SUCCESS(OK, "성공입니다."),
 
+    // 버전
+    GET_VERSION_INFO_SUCCESS(OK, "강제 업데이트 필요 여부 조회 성공입니다."),
+
     // 인증
     SIGNUP_SUCCESS(OK, "회원가입 성공입니다."),
     LOGIN_SUCCESS(OK, "로그인 성공입니다."),

--- a/src/main/java/hous/server/config/interceptor/version/VersionCheckHandler.java
+++ b/src/main/java/hous/server/config/interceptor/version/VersionCheckHandler.java
@@ -1,11 +1,9 @@
 package hous.server.config.interceptor.version;
 
-import hous.server.common.exception.ErrorCode;
-import hous.server.common.exception.NotFoundException;
 import hous.server.common.exception.UpgradeRequiredException;
-import hous.server.common.exception.ValidationException;
 import hous.server.domain.deploy.Deploy;
 import hous.server.domain.deploy.repository.DeployRepository;
+import hous.server.service.version.VersionServiceUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -20,43 +18,13 @@ public class VersionCheckHandler {
     public void checkVersion(HttpServletRequest request) {
         String requestOs = request.getHeader("HousOsType");
         String requestVersion = request.getHeader("HousVersion");
-        validateRequestOs(requestOs);
-        validateRequestVersion(requestVersion);
-        Deploy deploy = deployRepository.findDeployByOs(requestOs);
-        if (deploy == null) {
-            throw new NotFoundException(String.format("배포되지 않은 OS (%s) 입니다.", requestOs),
-                    ErrorCode.NOT_FOUND_OS_EXCEPTION);
-        }
+        VersionServiceUtils.validateRequestOs(requestOs);
+        VersionServiceUtils.validateRequestVersion(requestVersion);
+        Deploy deploy = VersionServiceUtils.findDeployByOs(deployRepository, requestOs);
         String latestVersion = deploy.getVersion();
-        if (isOutdated(requestVersion, latestVersion)) {
+        if (VersionServiceUtils.isOutdated(requestVersion, latestVersion)) {
             throw new UpgradeRequiredException(
                     String.format("업그레이드가 필요한 버전 (%s - %s) 입니다.", requestOs, requestVersion));
         }
-    }
-
-    private void validateRequestOs(String requestOs) {
-        if (!requestOs.matches("iOS|AOS")) {
-            throw new ValidationException(String.format("잘못된 OS 타입 요청 (%s) 입니다.", requestOs),
-                    ErrorCode.VALIDATION_OS_EXCEPTION);
-        }
-    }
-
-    private void validateRequestVersion(String requestVersion) {
-        if (!requestVersion.matches("\\d+\\.\\d+\\.\\d+")) {
-            throw new ValidationException(String.format("잘못된 버전 형식 (%s) 입니다.", requestVersion),
-                    ErrorCode.VALIDATION_VERSION_EXCEPTION);
-        }
-    }
-
-    private boolean isOutdated(String requestVersion, String latestVersion) {
-        String[] request = requestVersion.split("\\.");
-        String[] latest = latestVersion.split("\\.");
-        if (Integer.parseInt(request[0]) < Integer.parseInt(latest[0])) {
-            return true;
-        }
-        if (Integer.parseInt(request[1]) < Integer.parseInt(latest[1])) {
-            return true;
-        }
-        return false;
     }
 }

--- a/src/main/java/hous/server/controller/version/VersionRetrieveController.java
+++ b/src/main/java/hous/server/controller/version/VersionRetrieveController.java
@@ -1,0 +1,47 @@
+package hous.server.controller.version;
+
+import hous.server.common.dto.ErrorResponse;
+import hous.server.common.dto.SuccessResponse;
+import hous.server.common.success.SuccessCode;
+import hous.server.service.version.VersionRetrieveService;
+import hous.server.service.version.dto.response.VersionInfoResponse;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Api(tags = "Version")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/v1")
+public class VersionRetrieveController {
+
+    private final VersionRetrieveService versionRetrieveService;
+
+    @ApiOperation(
+            value = "버전 확인 - 강제 업데이트 필요 여부를 확인합니다.",
+            notes = "iOS/AOS 별로 강제 업데이트 필요 여부, 마켓 링크를 전달합니다.\n" +
+                    "헤더에 HousOsType, HousVersion 을 담아서 보내주세요."
+
+    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "강제 업데이트 필요 여부 조회 성공입니다."),
+            @ApiResponse(code = 400,
+                    message = "1. 잘못된 OS 타입 요청입니다.\n"
+                            + "2. 잘못된 버전 형식입니다.",
+                    response = ErrorResponse.class),
+            @ApiResponse(code = 404, message = "배포되지 않은 OS 입니다.", response = ErrorResponse.class),
+            @ApiResponse(code = 500, message = "예상치 못한 서버 에러가 발생하였습니다.", response = ErrorResponse.class)
+    })
+    @GetMapping("/version")
+    public ResponseEntity<SuccessResponse<VersionInfoResponse>> getVersionInfo(@RequestHeader("HousOsType") String requestOs,
+                                                                               @RequestHeader("HousVersion") String requestVersion) {
+        return SuccessResponse.success(SuccessCode.GET_VERSION_INFO_SUCCESS, versionRetrieveService.getVersionInfo(requestOs, requestVersion));
+    }
+}

--- a/src/main/java/hous/server/domain/deploy/Deploy.java
+++ b/src/main/java/hous/server/domain/deploy/Deploy.java
@@ -1,14 +1,11 @@
 package hous.server.domain.deploy;
 
 import hous.server.domain.common.AuditingTimeEntity;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
 
 @Getter
 @Entity
@@ -24,4 +21,7 @@ public class Deploy extends AuditingTimeEntity {
 
     @Column(nullable = false, length = 30)
     private String version;
+
+    @Column(nullable = false, length = 300)
+    private String marketUrl;
 }

--- a/src/main/java/hous/server/service/version/VersionRetrieveService.java
+++ b/src/main/java/hous/server/service/version/VersionRetrieveService.java
@@ -1,0 +1,25 @@
+package hous.server.service.version;
+
+import hous.server.domain.deploy.Deploy;
+import hous.server.domain.deploy.repository.DeployRepository;
+import hous.server.service.version.dto.response.VersionInfoResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class VersionRetrieveService {
+
+    private final DeployRepository deployRepository;
+
+    public VersionInfoResponse getVersionInfo(String requestOs, String requestVersion) {
+        VersionServiceUtils.validateRequestOs(requestOs);
+        VersionServiceUtils.validateRequestVersion(requestVersion);
+        Deploy deploy = VersionServiceUtils.findDeployByOs(deployRepository, requestOs);
+        String latestVersion = deploy.getVersion();
+        boolean needsForceUpdate = VersionServiceUtils.isOutdated(requestVersion, latestVersion);
+        return VersionInfoResponse.of(needsForceUpdate, deploy.getMarketUrl());
+    }
+}

--- a/src/main/java/hous/server/service/version/VersionServiceUtils.java
+++ b/src/main/java/hous/server/service/version/VersionServiceUtils.java
@@ -1,0 +1,48 @@
+package hous.server.service.version;
+
+import hous.server.common.exception.ErrorCode;
+import hous.server.common.exception.NotFoundException;
+import hous.server.common.exception.ValidationException;
+import hous.server.domain.deploy.Deploy;
+import hous.server.domain.deploy.repository.DeployRepository;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class VersionServiceUtils {
+
+    public static Deploy findDeployByOs(DeployRepository deployRepository, String os) {
+        Deploy deploy = deployRepository.findDeployByOs(os);
+        if (deploy == null) {
+            throw new NotFoundException(String.format("배포되지 않은 OS (%s) 입니다.", os),
+                    ErrorCode.NOT_FOUND_OS_EXCEPTION);
+        }
+        return deploy;
+    }
+
+    public static void validateRequestOs(String requestOs) {
+        if (!requestOs.matches("iOS|AOS")) {
+            throw new ValidationException(String.format("잘못된 OS 타입 요청 (%s) 입니다.", requestOs),
+                    ErrorCode.VALIDATION_OS_EXCEPTION);
+        }
+    }
+
+    public static void validateRequestVersion(String requestVersion) {
+        if (!requestVersion.matches("\\d+\\.\\d+\\.\\d+")) {
+            throw new ValidationException(String.format("잘못된 버전 형식 (%s) 입니다.", requestVersion),
+                    ErrorCode.VALIDATION_VERSION_EXCEPTION);
+        }
+    }
+
+    public static boolean isOutdated(String requestVersion, String latestVersion) {
+        String[] request = requestVersion.split("\\.");
+        String[] latest = latestVersion.split("\\.");
+        if (Integer.parseInt(request[0]) < Integer.parseInt(latest[0])) {
+            return true;
+        }
+        if (Integer.parseInt(request[1]) < Integer.parseInt(latest[1])) {
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/hous/server/service/version/dto/response/VersionInfoResponse.java
+++ b/src/main/java/hous/server/service/version/dto/response/VersionInfoResponse.java
@@ -1,0 +1,21 @@
+package hous.server.service.version.dto.response;
+
+import lombok.*;
+
+@ToString
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class VersionInfoResponse {
+
+    private boolean needsForceUpdate;
+    private String marketUrl;
+
+    public static VersionInfoResponse of(boolean needsForceUpdate, String marketUrl) {
+        return VersionInfoResponse.builder()
+                .needsForceUpdate(needsForceUpdate)
+                .marketUrl(marketUrl)
+                .build();
+    }
+}


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #258

## 🔑 Key Changes

1. 강제 업데이트 여부 조회 관련 api 구현
2. 기존에 @Version에서 사용하던 메서드들을 공통적으로 사용할 것 같아서 Util 파일로 리팩터링했습니다!
3. Deploy 테이블에 market_url 칼럼 추가

## 📢 To Reviewers
- market_url 은 안드측 요청으로 추가했습니다! 마켓 링크도 같이 보내줬으면 좋겠다고 해서요!
- 관련 쿼리 노션에 반영해뒀습니다.
