### PR TITLE
전체적으로 생년월일 optional 하게 처리하도록 수정

### DIFF
--- a/src/main/java/hous/server/common/exception/ErrorCode.java
+++ b/src/main/java/hous/server/common/exception/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     VALIDATION_STATUS_EXCEPTION(BAD_REQUEST, "잘못된 상태로 요청했습니다."),
     VALIDATION_RULE_MAX_LENGTH_EXCEPTION(BAD_REQUEST, "규칙은 20 글자 이내로 입력해주세요."),
     VALIDATION_RULE_MIN_LENGTH_EXCEPTION(BAD_REQUEST, "규칙 내용을 입력해주세요."),
+    VALIDATION_BIRTHDAY_EXCEPTION(BAD_REQUEST, "생년월일이 없는 경우 공개 여부는 true가 될 수 없습니다."),
 
     /**
      * 401 UnAuthorized

--- a/src/main/java/hous/server/common/util/DateUtils.java
+++ b/src/main/java/hous/server/common/util/DateUtils.java
@@ -16,6 +16,10 @@ public class DateUtils {
         return LocalDate.parse(date, DateTimeFormatter.ISO_DATE);
     }
 
+    public static String todayLocalDateToString() {
+        return LocalDate.now(ZoneId.of("Asia/Seoul")).toString();
+    }
+
     public static LocalDate todayLocalDate() {
         return LocalDate.now(ZoneId.of("Asia/Seoul"));
     }

--- a/src/main/java/hous/server/common/util/DateUtils.java
+++ b/src/main/java/hous/server/common/util/DateUtils.java
@@ -12,6 +12,10 @@ import java.time.format.DateTimeFormatter;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class DateUtils {
 
+    public static LocalDate toLocalDate(String date) {
+        return LocalDate.parse(date, DateTimeFormatter.ISO_DATE);
+    }
+
     public static LocalDate todayLocalDate() {
         return LocalDate.now(ZoneId.of("Asia/Seoul"));
     }

--- a/src/main/java/hous/server/controller/auth/AuthController.java
+++ b/src/main/java/hous/server/controller/auth/AuthController.java
@@ -46,7 +46,8 @@ public class AuthController {
     @ApiOperation(
             value = "온보딩 페이지 - 회원가입을 요청합니다.",
             notes = "카카오 회원가입, 애플 회원가입을 요청합니다.\n" +
-                    "socialType - KAKAO (카카오), APPLE (애플)"
+                    "socialType - KAKAO (카카오), APPLE (애플)\n" +
+                    "** iOS의 경우 생년월일을 아무것도 입력하지 않은 경우 -> birthday(\"\"), isPublic(false)로 부탁드립니다."
     )
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "회원가입 성공입니다."),
@@ -58,7 +59,8 @@ public class AuthController {
                             + "4. 닉네임을 입력해주세요. (nickname)\n"
                             + "5. 닉네임은 최대 3글자까지 가능합니다. (nickname)\n"
                             + "6. 생년월일을 입력해주세요. (birthday)\n"
-                            + "7. 생년월일을 공개 여부를 체크해주세요. (isPublic)",
+                            + "7. 생년월일을 공개 여부를 체크해주세요. (isPublic)\n"
+                            + "8. 생년월일이 없는 경우 공개 여부는 true가 될 수 없습니다.",
                     response = ErrorResponse.class),
             @ApiResponse(code = 401, message = "유효하지 않은 토큰입니다.", response = ErrorResponse.class),
             @ApiResponse(code = 409, message = "이미 해당 계정으로 회원가입하셨습니다.\n   로그인 해주세요.\n", response = ErrorResponse.class),

--- a/src/main/java/hous/server/controller/auth/dto/request/SignUpRequestDto.java
+++ b/src/main/java/hous/server/controller/auth/dto/request/SignUpRequestDto.java
@@ -1,6 +1,5 @@
 package hous.server.controller.auth.dto.request;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import hous.server.domain.common.Constraint;
 import hous.server.domain.user.UserSocialType;
@@ -11,7 +10,6 @@ import lombok.*;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-import java.time.LocalDate;
 
 @ToString
 @Getter
@@ -38,8 +36,7 @@ public class SignUpRequestDto {
 
     @ApiModelProperty(value = "생년월일", example = "1999-03-04")
     @NotNull(message = "{onboarding.birthday.notNull}")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
-    private LocalDate birthday;
+    private String birthday;
 
     @ApiModelProperty(value = "생년월일 공개 여부", example = "true")
     @NotNull(message = "{onboarding.isPublic.notNull}")

--- a/src/main/java/hous/server/controller/user/UserController.java
+++ b/src/main/java/hous/server/controller/user/UserController.java
@@ -36,7 +36,8 @@ public class UserController {
 
     @ApiOperation(
             value = "[인증] 마이 페이지(Profile 뷰) - 나의 프로필 정보를 수정합니다.",
-            notes = "프로필 정보 수정을 요청합니다. 자기소개에서 줄바꿈을 포함할 경우, ' '(공백)으로 변환하여 저장합니다."
+            notes = "프로필 정보 수정을 요청합니다. 자기소개에서 줄바꿈을 포함할 경우, ' '(공백)으로 변환하여 저장합니다.\n" +
+                    "** iOS의 경우 생년월일을 아무것도 입력하지 않은 경우 -> birthday(\"\"), isPublic(false)로 부탁드립니다."
     )
     @ApiResponses(value = {
             @ApiResponse(code = 200, message = "성공입니다."),
@@ -48,7 +49,8 @@ public class UserController {
                             + "4. 생년월일을 공개 여부를 체크해주세요. (isPublic)\n"
                             + "5. mbti 는 4 글자 이내로 입력해주세요. (mbti)\n"
                             + "6. 직업은 3 글자 이내로 입력해주세요. (job)\n"
-                            + "7. 자기소개는 40 글자 이내로 입력해주세요. (introduction)",
+                            + "7. 자기소개는 40 글자 이내로 입력해주세요. (introduction)\n"
+                            + "8. 생년월일이 없는 경우 공개 여부는 true가 될 수 없습니다.",
                     response = ErrorResponse.class),
             @ApiResponse(code = 401, message = "토큰이 만료되었습니다. 다시 로그인 해주세요.", response = ErrorResponse.class),
             @ApiResponse(code = 404,

--- a/src/main/java/hous/server/domain/user/Onboarding.java
+++ b/src/main/java/hous/server/domain/user/Onboarding.java
@@ -1,6 +1,5 @@
 package hous.server.domain.user;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import hous.server.domain.badge.Acquire;
 import hous.server.domain.badge.Represent;
 import hous.server.domain.common.AuditingTimeEntity;
@@ -11,7 +10,6 @@ import hous.server.service.user.dto.request.UpdateUserInfoRequestDto;
 import lombok.*;
 
 import javax.persistence.*;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,8 +32,7 @@ public class Onboarding extends AuditingTimeEntity implements Comparable<Onboard
     private String nickname;
 
     @Column(nullable = false)
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
-    private LocalDate birthday;
+    private String birthday;
 
     @Column(length = 100)
     private String introduction;
@@ -69,7 +66,7 @@ public class Onboarding extends AuditingTimeEntity implements Comparable<Onboard
     @OneToMany(mappedBy = "onboarding", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<Notification> notifications = new ArrayList<>();
 
-    public static Onboarding newInstance(User user, Personality personality, String nickname, LocalDate birthday, boolean isPublic) {
+    public static Onboarding newInstance(User user, Personality personality, String nickname, String birthday, boolean isPublic) {
         return Onboarding.builder()
                 .user(user)
                 .personality(personality)

--- a/src/main/java/hous/server/domain/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/hous/server/domain/user/repository/UserRepositoryCustom.java
@@ -3,7 +3,6 @@ package hous.server.domain.user.repository;
 import hous.server.domain.user.User;
 import hous.server.domain.user.UserSocialType;
 
-import java.time.LocalDate;
 import java.util.List;
 
 public interface UserRepositoryCustom {
@@ -18,5 +17,5 @@ public interface UserRepositoryCustom {
 
     List<User> findAllUsers();
 
-    List<User> findAllUserByBirthday(LocalDate birthday);
+    List<User> findAllUsersByBirthday(String birthday);
 }

--- a/src/main/java/hous/server/domain/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/hous/server/domain/user/repository/UserRepositoryImpl.java
@@ -6,7 +6,6 @@ import hous.server.domain.user.UserSocialType;
 import hous.server.domain.user.UserStatus;
 import lombok.RequiredArgsConstructor;
 
-import java.time.LocalDate;
 import java.util.List;
 
 import static hous.server.domain.user.QUser.user;
@@ -70,7 +69,7 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
     }
 
     @Override
-    public List<User> findAllUserByBirthday(LocalDate birthday) {
+    public List<User> findAllUsersByBirthday(String birthday) {
         return queryFactory
                 .selectFrom(user)
                 .where(

--- a/src/main/java/hous/server/service/auth/dto/request/SignUpDto.java
+++ b/src/main/java/hous/server/service/auth/dto/request/SignUpDto.java
@@ -5,8 +5,6 @@ import hous.server.domain.user.UserSocialType;
 import hous.server.service.user.dto.request.CreateUserRequestDto;
 import lombok.*;
 
-import java.time.LocalDate;
-
 @ToString
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -18,7 +16,7 @@ public class SignUpDto {
     private String token;
     private String fcmToken;
     private String nickname;
-    private LocalDate birthday;
+    private String birthday;
     private Boolean isPublic;
 
     @JsonProperty("isPublic")
@@ -27,7 +25,7 @@ public class SignUpDto {
     }
 
     public static SignUpDto of(UserSocialType socialType, String token, String fcmToken,
-                               String nickname, LocalDate birthday, Boolean isPublic) {
+                               String nickname, String birthday, Boolean isPublic) {
         return SignUpDto.builder()
                 .socialType(socialType)
                 .token(token)

--- a/src/main/java/hous/server/service/user/UserScheduledService.java
+++ b/src/main/java/hous/server/service/user/UserScheduledService.java
@@ -26,7 +26,7 @@ public class UserScheduledService {
      */
     @Scheduled(cron = "0  0  9  *  *  *")
     public void scheduledTodayBirthday() {
-        List<User> users = userRepository.findAllUserByBirthday(DateUtils.todayLocalDate());
+        List<User> users = userRepository.findAllUsersByBirthday(DateUtils.todayLocalDateToString());
         users.forEach(user -> badgeService.acquireBadge(user, BadgeInfo.HOMIE_IS_BORN));
     }
 }

--- a/src/main/java/hous/server/service/user/UserService.java
+++ b/src/main/java/hous/server/service/user/UserService.java
@@ -70,6 +70,7 @@ public class UserService {
 
     public Long registerUser(CreateUserRequestDto request) {
         UserServiceUtils.validateNotExistsUser(userRepository, request.getSocialId(), request.getSocialType());
+        UserServiceUtils.validateBirthdayAndIsPublic(request.getBirthday(), request.isPublic());
         User user = userRepository.save(User.newInstance(
                 request.getSocialId(), request.getSocialType(),
                 settingRepository.save(Setting.newInstance())));

--- a/src/main/java/hous/server/service/user/UserService.java
+++ b/src/main/java/hous/server/service/user/UserService.java
@@ -91,6 +91,7 @@ public class UserService {
     }
 
     public void updateUserInfo(UpdateUserInfoRequestDto request, Long userId) {
+        UserServiceUtils.validateBirthdayAndIsPublic(request.getBirthday(), request.isPublic());
         User user = UserServiceUtils.findUserById(userRepository, userId);
         RoomServiceUtils.findParticipatingRoom(user);
         Onboarding onboarding = user.getOnboarding();

--- a/src/main/java/hous/server/service/user/UserServiceUtils.java
+++ b/src/main/java/hous/server/service/user/UserServiceUtils.java
@@ -137,4 +137,10 @@ public class UserServiceUtils {
     public static boolean isNewFeedback(FeedbackType feedbackType, String comment) {
         return !(feedbackType.equals(FeedbackType.NO) && comment.isBlank());
     }
+
+    public static void validateBirthdayAndIsPublic(String birthday, Boolean isPublic) {
+        if (birthday.equals("") && isPublic) {
+            throw new ValidationException(String.format("생년월일 (\"\") 을 지정하지 않은 경우, 공개 여부 (%s) 를 지정할 수 없습니다.", birthday, isPublic), VALIDATION_BIRTHDAY_EXCEPTION);
+        }
+    }
 }

--- a/src/main/java/hous/server/service/user/dto/request/CreateUserRequestDto.java
+++ b/src/main/java/hous/server/service/user/dto/request/CreateUserRequestDto.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import hous.server.domain.user.UserSocialType;
 import lombok.*;
 
-import java.time.LocalDate;
-
 @ToString
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -17,7 +15,7 @@ public class CreateUserRequestDto {
     private UserSocialType socialType;
     private String fcmToken;
     private String nickname;
-    private LocalDate birthday;
+    private String birthday;
     private Boolean isPublic;
 
     @JsonProperty("isPublic")
@@ -26,7 +24,7 @@ public class CreateUserRequestDto {
     }
 
     public static CreateUserRequestDto of(String socialId, UserSocialType socialType, String fcmToken,
-                                          String nickname, LocalDate birthday, Boolean isPublic) {
+                                          String nickname, String birthday, Boolean isPublic) {
         return CreateUserRequestDto.builder()
                 .socialId(socialId)
                 .socialType(socialType)

--- a/src/main/java/hous/server/service/user/dto/request/UpdateUserInfoRequestDto.java
+++ b/src/main/java/hous/server/service/user/dto/request/UpdateUserInfoRequestDto.java
@@ -1,7 +1,6 @@
 package hous.server.service.user.dto.request;
 
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import hous.server.domain.common.Constraint;
 import io.swagger.annotations.ApiModelProperty;
@@ -13,7 +12,6 @@ import lombok.ToString;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-import java.time.LocalDate;
 
 @ToString
 @Getter
@@ -27,8 +25,7 @@ public class UpdateUserInfoRequestDto {
 
     @ApiModelProperty(value = "생년월일", example = "1999-03-04")
     @NotNull(message = "{onboarding.birthday.notNull}")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
-    private LocalDate birthday;
+    private String birthday;
 
     @ApiModelProperty(value = "생년월일 공개 여부", example = "true")
     @NotNull(message = "{onboarding.isPublic.notNull}")

--- a/src/main/java/hous/server/service/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/hous/server/service/user/dto/response/UserInfoResponse.java
@@ -78,8 +78,8 @@ public class UserInfoResponse {
                 .personalityColor(onboarding.getPersonality().getColor())
                 .nickname(onboarding.getNickname())
                 .birthdayPublic(onboarding.isPublic())
-                .age(MathUtils.getAge(onboarding.getBirthday()) + "세")
-                .birthday(DateUtils.parseYearAndMonthAndDay(onboarding.getBirthday()))
+                .age(toDisplayAge(onboarding.getBirthday()))
+                .birthday(toDisplayBirthday(onboarding.getBirthday()))
                 .mbti(onboarding.getMbti())
                 .job(onboarding.getJob())
                 .mbti(onboarding.getMbti())
@@ -88,5 +88,19 @@ public class UserInfoResponse {
                 .representBadge(represent != null ? represent.getBadge().getInfo().getValue() : null)
                 .representBadgeImage(represent != null ? represent.getBadge().getImageUrl() : null)
                 .build();
+    }
+
+    private static String toDisplayAge(String birthday) {
+        if (birthday.equals("")) {
+            return birthday;
+        }
+        return MathUtils.getAge(DateUtils.toLocalDate(birthday)) + "세";
+    }
+
+    private static String toDisplayBirthday(String birthday) {
+        if (birthday.equals("")) {
+            return birthday;
+        }
+        return DateUtils.parseYearAndMonthAndDay(DateUtils.toLocalDate(birthday));
     }
 }


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #283

## 🔑 Key Changes

1. Onboarding 엔티티 birthday 데이터타입 LocalDate -> String
   - 생년월일을 생략하는 경우 ""로 클라에서 보내신다고 하셔서 String으로 수정했습니다. **괜찮나요?!** (기존에 nullable = false 였길래요!)
   - 기존 형태(LocalDate) 유지하고 nuallble = true로 수정하려고 했는데 
      - 안드한테 물어보니까 어차피 String 형태로 주고 있고, 기존에도 LocalDate -> String 형태로 박는거였어서 String 으로 변경함!
2. 회원가입 시  birthday optional 반영 (`birthday="", isPublic=false`)
   - `birthday="", isPublic=true`이면 400 에러 던집니다.
3. 프로필 정보 수정 시 birthday optional 반영 (`birthday="", isPublic=false`)
4. 나/룸메이트 조회 시 생년월일이 없는 경우 빈 스트링 보내도록 response 수정
5. 호미의 탄생 배지 스케줄러 돌릴 때 엔티티 데이터 타입 변경으로 DateUtils 에 `오늘날짜.toString()` 하는 함수 만들어서 수정

## 📢 To Reviewers
- 나/룸메이트 조회 시 age, birthday 부분이 없는 경우
   -  "" 또는 null로 전달해주는게 의진오빠가 더 편하다고 해서 호옥시 안드는 null 처리를 안했을까봐 ""로 수정했습니다!
