### PR TITLE
#289 [!HOTFIX] todo 메인 조회 시 ourTodo의 체크 상태 이슈 해결

### DIFF
--- a/src/main/java/hous/server/domain/todo/repository/DoneRepositoryImpl.java
+++ b/src/main/java/hous/server/domain/todo/repository/DoneRepositoryImpl.java
@@ -10,7 +10,8 @@ import hous.server.domain.user.Onboarding;
 import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDate;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 import static hous.server.domain.todo.QDone.done;
 
@@ -34,7 +35,14 @@ public class DoneRepositoryImpl implements DoneRepositoryCustom {
 
     @Override
     public OurTodoStatus findTodayOurTodoStatus(LocalDate today, Todo todo) {
-        List<Take> takes = todo.getTakes();
+        Set<Take> takes = new HashSet<>();
+        todo.getTakes().forEach(take -> {
+            take.getRedos().forEach(redo -> {
+                if (redo.getDayOfWeek().toString().equals(DateUtils.nowDayOfWeek(today))) {
+                    takes.add(take);
+                }
+            });
+        });
         int doneCnt = (int) takes.stream()
                 .map(take -> queryFactory.selectFrom(done)
                         .where(


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #289

## 🔑 Key Changes

1. 모든 takes를 가져와서 done의 개수를 체크하는 부분을 오늘 날짜의 takes를 이용하도록 변경했습니다.
   - 예를 들어 '혜정 월수금, 혁준 화목토' todo가 있는데 take는 2지만, 오늘 날짜의 take는 1임
   - takes.size()와 done 개수로 체크 상태 (EMPTY, FULL, FULL_CHECK)를 구분해서 이렇게 변경함
   
## 📢 To Reviewers
- 스웨거로 확인함요 ㅠ 
```json
{
  "status": 200,
  "success": true,
  "message": "todo 메인 페이지 조회 성공입니다.",
  "data": {
    "date": "12.28",
    "dayOfWeek": "WEDNESDAY",
    "progress": 66,
    "myTodosCnt": 3,
    "ourTodosCnt": 3,
    "myTodos": [
      {
        "todoId": 1,
        "todoName": "청소기 돌리기",
        "isChecked": true
      },
      {
        "todoId": 2,
        "todoName": "빨래 개기",
        "isChecked": true
      },
      {
        "todoId": 3,
        "todoName": "둘 다 할 일",
        "isChecked": true
      }
    ],
    "ourTodos": [
      {
        "todoName": "청소기 돌리기",
        "nicknames": [
          "혜조니"
        ],
        "status": "FULL_CHECK"
      },
      {
        "todoName": "빨래 개기",
        "nicknames": [
          "혜조니",
          "혁돌이"
        ],
        "status": "FULL_CHECK"
      },
      {
        "todoName": "둘 다 할 일",
        "nicknames": [
          "혜조니",
          "혁돌이"
        ],
        "status": "FULL"
      }
    ]
  }
}
```
