### PR TITLE
 controller 메소드 실행 시점에 모든 요청에 대하여 request 내용 log 기록하기

### DIFF
--- a/src/main/java/hous/server/ServerApplication.java
+++ b/src/main/java/hous/server/ServerApplication.java
@@ -3,6 +3,7 @@ package hous.server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
@@ -10,6 +11,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 @EnableScheduling
 @EnableFeignClients
 @EnableJpaAuditing
+@EnableAspectJAutoProxy
 @SpringBootApplication
 @EnableSwagger2
 public class ServerApplication {

--- a/src/main/java/hous/server/common/aspect/duplicate/PreventDuplicateRequest.java
+++ b/src/main/java/hous/server/common/aspect/duplicate/PreventDuplicateRequest.java
@@ -1,4 +1,4 @@
-package hous.server.common.aspect;
+package hous.server.common.aspect.duplicate;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/hous/server/common/aspect/duplicate/RequestAspect.java
+++ b/src/main/java/hous/server/common/aspect/duplicate/RequestAspect.java
@@ -1,4 +1,4 @@
-package hous.server.common.aspect;
+package hous.server.common.aspect.duplicate;
 
 import hous.server.common.exception.ConflictException;
 import hous.server.domain.common.RedisKey;
@@ -19,7 +19,7 @@ public class RequestAspect {
 
     private final RedisTemplate<String, Object> redisTemplate;
 
-    @Before("@annotation(hous.server.common.aspect.PreventDuplicateRequest)")
+    @Before("@annotation(hous.server.common.aspect.duplicate.PreventDuplicateRequest)")
     public void beforeRequest(final JoinPoint joinPoint) {
         Long userId = (Long) joinPoint.getArgs()[0];
         if (redisTemplate.opsForValue().get(RedisKey.DUPLICATE_REQUEST + userId) != null) {
@@ -29,7 +29,7 @@ public class RequestAspect {
         redisTemplate.opsForValue().set(RedisKey.DUPLICATE_REQUEST + userId, Long.toString(userId));
     }
 
-    @After("@annotation(hous.server.common.aspect.PreventDuplicateRequest)")
+    @After("@annotation(hous.server.common.aspect.duplicate.PreventDuplicateRequest)")
     public void afterReturningRequest(final JoinPoint joinPoint) {
         Long userId = (Long) joinPoint.getArgs()[0];
         redisTemplate.opsForValue().getAndDelete(RedisKey.DUPLICATE_REQUEST + userId);

--- a/src/main/java/hous/server/common/aspect/logging/RequestLoggingAspect.java
+++ b/src/main/java/hous/server/common/aspect/logging/RequestLoggingAspect.java
@@ -1,0 +1,49 @@
+package hous.server.common.aspect.logging;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+@Aspect
+@Component
+@Slf4j
+public class RequestLoggingAspect {
+
+    @Pointcut("within(hous.server.controller..*)")
+    public void onRequest() {
+    }
+
+    @Around("hous.server.common.aspect.logging.RequestLoggingAspect.onRequest()")
+    public Object requestLogging(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+        long startAt = System.currentTimeMillis();
+        try {
+            return proceedingJoinPoint.proceed(proceedingJoinPoint.getArgs());
+        } finally {
+            long endAt = System.currentTimeMillis();
+            log.info("====> Request: {} {} ({}ms)\n *Header = {}\n", request.getMethod(), request.getRequestURL(), endAt - startAt, getHeaders(request));
+        }
+
+    }
+
+    private Map<String, Object> getHeaders(HttpServletRequest request) {
+        Map<String, Object> headerMap = new HashMap<>();
+
+        Enumeration<String> headerArray = request.getHeaderNames();
+        while (headerArray.hasMoreElements()) {
+            String headerName = headerArray.nextElement();
+            headerMap.put(headerName, request.getHeader(headerName));
+        }
+        return headerMap;
+    }
+}

--- a/src/main/java/hous/server/controller/auth/AuthController.java
+++ b/src/main/java/hous/server/controller/auth/AuthController.java
@@ -1,6 +1,6 @@
 package hous.server.controller.auth;
 
-import hous.server.common.aspect.PreventDuplicateRequest;
+import hous.server.common.aspect.duplicate.PreventDuplicateRequest;
 import hous.server.common.dto.ErrorResponse;
 import hous.server.common.dto.SuccessResponse;
 import hous.server.common.success.SuccessCode;

--- a/src/main/java/hous/server/controller/room/RoomController.java
+++ b/src/main/java/hous/server/controller/room/RoomController.java
@@ -1,6 +1,6 @@
 package hous.server.controller.room;
 
-import hous.server.common.aspect.PreventDuplicateRequest;
+import hous.server.common.aspect.duplicate.PreventDuplicateRequest;
 import hous.server.common.dto.ErrorResponse;
 import hous.server.common.dto.SuccessResponse;
 import hous.server.common.success.SuccessCode;

--- a/src/main/java/hous/server/controller/rule/RuleController.java
+++ b/src/main/java/hous/server/controller/rule/RuleController.java
@@ -1,6 +1,6 @@
 package hous.server.controller.rule;
 
-import hous.server.common.aspect.PreventDuplicateRequest;
+import hous.server.common.aspect.duplicate.PreventDuplicateRequest;
 import hous.server.common.dto.ErrorResponse;
 import hous.server.common.dto.SuccessResponse;
 import hous.server.config.interceptor.auth.Auth;

--- a/src/main/java/hous/server/controller/todo/TodoController.java
+++ b/src/main/java/hous/server/controller/todo/TodoController.java
@@ -1,6 +1,6 @@
 package hous.server.controller.todo;
 
-import hous.server.common.aspect.PreventDuplicateRequest;
+import hous.server.common.aspect.duplicate.PreventDuplicateRequest;
 import hous.server.common.dto.ErrorResponse;
 import hous.server.common.dto.SuccessResponse;
 import hous.server.config.interceptor.auth.Auth;

--- a/src/main/java/hous/server/controller/user/UserController.java
+++ b/src/main/java/hous/server/controller/user/UserController.java
@@ -1,6 +1,6 @@
 package hous.server.controller.user;
 
-import hous.server.common.aspect.PreventDuplicateRequest;
+import hous.server.common.aspect.duplicate.PreventDuplicateRequest;
 import hous.server.common.dto.ErrorResponse;
 import hous.server.common.dto.SuccessResponse;
 import hous.server.common.success.SuccessCode;


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #292

## 🔑 Key Changes

1.  controller 메소드 실행 시점에 모든 요청에 대하여 request 내용 log 기록하기
2. response  내용 log 기록하기 추가
   - 처음에 `@AfterReturning` 을 이용해서 200 성공한 데이터들만 info에 담으려고 했으나 
   -`@Around` 어노테이션의 경우 포인트 컷으로 걸어놓은 **메소드 시작 시점 ~ 끝나는 시점**까지 모두 읽혀서 이 안에서 동작하도록 변경했습니다. 
      - [이 블로그](https://pgnt.tistory.com/103) 보시면 실행 시점마다 로그 찍으신게 있는데 보시면 알 수 있음! 

info.log
```
[2023-01-29 23:35:37:75650] [32m[http-nio-8080-exec-1][0;39m [34mINFO [0;39m [1;37m[hous.server.common.aspect.logging.LoggingAspect.requestLogging:[33m32[0;39m][0;39m - ====> Request: POST http://localhost:8080/v1/auth/login/force (2ms)
 *Header = {sec-fetch-mode=cors, content-length=188, referer=http://localhost:8080/swagger-ui.html, sec-fetch-site=same-origin, accept-language=ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7, origin=http://localhost:8080, housostype=iOS, accept=application/json;charset=UTF-8, housversion=1.0.0, sec-ch-ua="Chromium";v="106", "Google Chrome";v="106", "Not;A=Brand";v="99", sec-ch-ua-mobile=?0, sec-ch-ua-platform="macOS", host=localhost:8080, connection=keep-alive, content-type=application/json;charset=UTF-8, accept-encoding=gzip, deflate, br, user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36, sec-fetch-dest=empty}

[2023-01-29 23:35:37:75650] [32m[http-nio-8080-exec-1][0;39m [34mINFO [0;39m [1;37m[hous.server.common.aspect.logging.LoggingAspect.requestLogging:[33m34[0;39m][0;39m - ====> Response: <401,ErrorResponse(status=401, success=false, message=유효하지 않은 토큰입니다.),[]>
[2023-01-29 23:35:52:90641] [32m[http-nio-8080-exec-2][0;39m [34mINFO [0;39m [1;37m[hous.server.common.aspect.logging.LoggingAspect.requestLogging:[33m32[0;39m][0;39m - ====> Request: POST http://localhost:8080/v1/auth/login/force (0ms)
 *Header = {sec-fetch-mode=cors, content-length=188, referer=http://localhost:8080/swagger-ui.html, sec-fetch-site=same-origin, accept-language=ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7, origin=http://localhost:8080, housostype=iOS, accept=application/json;charset=UTF-8, housversion=1.0.0, sec-ch-ua="Chromium";v="106", "Google Chrome";v="106", "Not;A=Brand";v="99", sec-ch-ua-mobile=?0, sec-ch-ua-platform="macOS", host=localhost:8080, connection=keep-alive, content-type=application/json;charset=UTF-8, accept-encoding=gzip, deflate, br, user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36, sec-fetch-dest=empty}

[2023-01-29 23:35:52:90957] [32m[http-nio-8080-exec-2][0;39m [34mINFO [0;39m [1;37m[hous.server.common.aspect.logging.LoggingAspect.requestLogging:[33m32[0;39m][0;39m - ====> Request: POST http://localhost:8080/v1/auth/login/force (313ms)
 *Header = {sec-fetch-mode=cors, content-length=188, referer=http://localhost:8080/swagger-ui.html, sec-fetch-site=same-origin, accept-language=ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7, origin=http://localhost:8080, housostype=iOS, accept=application/json;charset=UTF-8, housversion=1.0.0, sec-ch-ua="Chromium";v="106", "Google Chrome";v="106", "Not;A=Brand";v="99", sec-ch-ua-mobile=?0, sec-ch-ua-platform="macOS", host=localhost:8080, connection=keep-alive, content-type=application/json;charset=UTF-8, accept-encoding=gzip, deflate, br, user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/106.0.0.0 Safari/537.36, sec-fetch-dest=empty}

[2023-01-29 23:35:52:90957] [32m[http-nio-8080-exec-2][0;39m [34mINFO [0;39m [1;37m[hous.server.common.aspect.logging.LoggingAspect.requestLogging:[33m34[0;39m][0;39m - ====> Response: <200,SuccessResponse(status=200, success=true, message=로그인 성공입니다., data=LoginResponse(userId=1, token=TokenResponse(accessToken=eyJhbGciOiJIUzUxMiJ9.eyJVU0VSX0lEIjoxLCJleHAiOjE2NzUwMDM1NTJ9.0i4MtKHYdLr0rtPEZ4DDZDSMgSOhWS7T-GSP6JOV778RSFc5RtbsdBP7y_OUSYg05JLHTXmHZVsTy3vyIdsphQ, refreshToken=eyJhbGciOiJIUzUxMiJ9.eyJleHAiOjE2OTA1NTQ5NTJ9.7pC5HPPakB8gSjqTuOREUzCX_RfXt50Xt3AuCdL-mv4WQ9VM2KQU0CXOhvI_IhkZpZugQfKr4YqM9DrUWN8X3w), isJoiningRoom=true)),[]>
```
- 이런 식으로 성공/실패에 대한 에러 모두 직히도록 했습니다. 괜찮나요 ?ㅠ 
- 저희가 SuccessResponse 를 ResponseEntity로 한번 묶어서 보내서 <statuscode, body, []> 형태로 찍히는 것으로 생각됩니다... 
  - body 만 따로 빼고 싶은데 그럼 다소 상당스 귀찮은 작업이 추가될 것 같아서 우선 이렇게 함 >< 
  
## 📢 To Reviewers
- log 정보를 request, response 찍도록 @Around 를 이용해서 AOP로 구현했습니다.

## 참고자료
- [controller logging 처리](https://hirlawldo.tistory.com/31)
  - [request header 뽑아오기](https://oops4u.tistory.com/2602)