### PR TITLE
배지 관련 데이터 mongoDB 적용하는 방식으로 로직 수정

### DIFF
--- a/src/main/java/hous/server/domain/badge/BadgeCounter.java
+++ b/src/main/java/hous/server/domain/badge/BadgeCounter.java
@@ -24,21 +24,21 @@ public class BadgeCounter extends AuditingTimeEntity {
     @Field(name = "user_id")
     private Long userId;
 
-    @Field(name = "rule_create_count")
-    private int ruleCreateCount;
+    @Field(name = "count_type")
+    private BadgeCounterType countType;
 
-    @Field(name = "todo_complete_count")
-    private int todoCompleteCount;
+    @Field(name = "count")
+    private int count;
 
-    @Field(name = "test_score_complete_count")
-    private int testScoreCompleteCount;
-
-    public static BadgeCounter newInstance(Long userId) {
+    public static BadgeCounter newInstance(Long userId, BadgeCounterType countType, int count) {
         return BadgeCounter.builder()
                 .userId(userId)
-                .ruleCreateCount(0)
-                .todoCompleteCount(0)
-                .testScoreCompleteCount(0)
+                .countType(countType)
+                .count(count)
                 .build();
+    }
+
+    public void updateCount(int count) {
+        this.count = count;
     }
 }

--- a/src/main/java/hous/server/domain/badge/BadgeCounterType.java
+++ b/src/main/java/hous/server/domain/badge/BadgeCounterType.java
@@ -1,0 +1,27 @@
+package hous.server.domain.badge;
+
+import hous.server.common.model.EnumModel;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum BadgeCounterType implements EnumModel {
+
+    RULE_CREATE("RULE_CREATE"),
+    TODO_COMPLETE("TODO_COMPLETE"),
+    TEST_SCORE_COMPLETE("TEST_SCORE_COMPLETE");
+
+    private final String value;
+
+    @Override
+    public String getKey() {
+        return name();
+    }
+
+    @Override
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/hous/server/domain/badge/BadgeCounterType.java
+++ b/src/main/java/hous/server/domain/badge/BadgeCounterType.java
@@ -1,27 +1,7 @@
 package hous.server.domain.badge;
 
-import hous.server.common.model.EnumModel;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
-@Getter
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-public enum BadgeCounterType implements EnumModel {
-
-    RULE_CREATE("RULE_CREATE"),
-    TODO_COMPLETE("TODO_COMPLETE"),
-    TEST_SCORE_COMPLETE("TEST_SCORE_COMPLETE");
-
-    private final String value;
-
-    @Override
-    public String getKey() {
-        return name();
-    }
-
-    @Override
-    public String getValue() {
-        return value;
-    }
+public enum BadgeCounterType {
+    RULE_CREATE,
+    TODO_COMPLETE,
+    TEST_SCORE_COMPLETE;
 }

--- a/src/main/java/hous/server/domain/badge/mongo/BadgeCounterRepository.java
+++ b/src/main/java/hous/server/domain/badge/mongo/BadgeCounterRepository.java
@@ -1,7 +1,11 @@
 package hous.server.domain.badge.mongo;
 
 import hous.server.domain.badge.BadgeCounter;
+import hous.server.domain.badge.BadgeCounterType;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 public interface BadgeCounterRepository extends MongoRepository<BadgeCounter, Long> {
+    BadgeCounter findByUserIdAndCountType(Long userId, BadgeCounterType countType);
+
+    void deleteBadgeCounterByUserIdAndCountType(Long userId, BadgeCounterType countType);
 }

--- a/src/main/java/hous/server/service/user/dto/request/UpdateTestScoreRequestDto.java
+++ b/src/main/java/hous/server/service/user/dto/request/UpdateTestScoreRequestDto.java
@@ -11,6 +11,7 @@ import javax.validation.constraints.Min;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class UpdateTestScoreRequestDto {
 
     @ApiModelProperty(value = "빛", example = "4")
@@ -37,4 +38,14 @@ public class UpdateTestScoreRequestDto {
     @Min(value = Constraint.ONBOARDING_TESTSCORE_MIN, message = "{onboarding.testScore.size}")
     @Max(value = Constraint.ONBOARDING_TESTSCORE_MAX, message = "{onboarding.testScore.size}")
     private int introversion;
+
+    public static UpdateTestScoreRequestDto of (int light, int noise, int clean, int smell, int introversion) {
+        return UpdateTestScoreRequestDto.builder()
+                .light(light)
+                .noise(noise)
+                .clean(clean)
+                .smell(smell)
+                .introversion(introversion)
+                .build();
+    }
 }

--- a/src/test/java/hous/server/service/badge/BadgeServiceTest.java
+++ b/src/test/java/hous/server/service/badge/BadgeServiceTest.java
@@ -100,7 +100,7 @@ public class BadgeServiceTest {
         // then
         List<Acquire> acquires = acquireRepository.findAllAcquireByOnboarding(user.getOnboarding());
         Acquire acquireBadge = acquires.stream()
-                .filter(acquire -> BadgeInfo.I_AM_SUCH_A_PERSON.equals(acquire.getBadge().getInfo()))
+                .filter(acquire -> BadgeInfo.POUNDING_HOUSE.equals(acquire.getBadge().getInfo()))
                 .findAny()
                 .orElse(null);
         assertThat(acquires).hasSize(1);
@@ -132,8 +132,9 @@ public class BadgeServiceTest {
         assertThat(acquireBadge).isNotNull();
         assertThat(updatePersonalityColorResponse.getColor()).isEqualTo(PersonalityColor.YELLOW);
 
-        BadgeCounter badgeCounter = badgeCounterRepository.findAllByUserIdAndCountType(userId, BadgeCounterType.TEST_SCORE_COMPLETE);
+        BadgeCounter badgeCounter = badgeCounterRepository.findByUserIdAndCountType(userId, BadgeCounterType.TEST_SCORE_COMPLETE);
         assertThat(badgeCounter).isNotNull();
+        assertThat(badgeCounter.getCount()).isEqualTo(1);
     }
 
     @Test
@@ -206,8 +207,8 @@ public class BadgeServiceTest {
         assertThat(acquiresByUser).hasSize(4);
         assertThat(acquireBadge).isNotNull();
         assertThat(user.getOnboarding().getPersonality().getColor()).isEqualTo(updatePersonalityColorResponse.getColor());
-        
-        BadgeCounter badgeCounter = badgeCounterRepository.findAllByUserIdAndCountType(userId, BadgeCounterType.TEST_SCORE_COMPLETE);
+
+        BadgeCounter badgeCounter = badgeCounterRepository.findByUserIdAndCountType(userId, BadgeCounterType.TEST_SCORE_COMPLETE);
         assertThat(badgeCounter).isNull(); // 배지를 받으면 삭제되니까 데이터가 없어야 해
     }
 
@@ -298,6 +299,10 @@ public class BadgeServiceTest {
                 .orElse(null);
         assertThat(acquiresByUser).hasSize(2);
         assertThat(acquireBadge).isNotNull();
+
+        BadgeCounter badgeCounter = badgeCounterRepository.findByUserIdAndCountType(userId, BadgeCounterType.RULE_CREATE);
+        assertThat(badgeCounter).isNotNull();
+        assertThat(badgeCounter.getCount()).isEqualTo(1);
     }
 
     @Test
@@ -328,6 +333,9 @@ public class BadgeServiceTest {
                 .orElse(null);
         assertThat(acquiresByUser).hasSize(3);
         assertThat(acquireBadge).isNotNull();
+
+        BadgeCounter badgeCounter = badgeCounterRepository.findByUserIdAndCountType(userId, BadgeCounterType.RULE_CREATE);
+        assertThat(badgeCounter).isNull(); // 배지를 받으면 삭제되니까 데이터가 없어야 해
     }
 
     @Test

--- a/src/test/java/hous/server/service/badge/BadgeServiceTest.java
+++ b/src/test/java/hous/server/service/badge/BadgeServiceTest.java
@@ -1,0 +1,344 @@
+package hous.server.service.badge;
+
+import hous.server.common.util.DateUtils;
+import hous.server.domain.badge.Acquire;
+import hous.server.domain.badge.BadgeInfo;
+import hous.server.domain.badge.mysql.AcquireRepository;
+import hous.server.domain.badge.mysql.BadgeRepository;
+import hous.server.domain.personality.PersonalityColor;
+import hous.server.domain.rule.Rule;
+import hous.server.domain.rule.mysql.RuleRepository;
+import hous.server.domain.todo.DayOfWeek;
+import hous.server.domain.todo.Todo;
+import hous.server.domain.todo.mysql.TodoRepository;
+import hous.server.domain.user.User;
+import hous.server.domain.user.UserSocialType;
+import hous.server.domain.user.mysql.UserRepository;
+import hous.server.service.room.RoomService;
+import hous.server.service.room.dto.request.SetRoomNameRequestDto;
+import hous.server.service.room.dto.response.RoomInfoResponse;
+import hous.server.service.rule.RuleService;
+import hous.server.service.rule.dto.request.CreateRuleRequestDto;
+import hous.server.service.todo.TodoService;
+import hous.server.service.todo.dto.request.TodoInfoRequestDto;
+import hous.server.service.user.UserService;
+import hous.server.service.user.dto.request.CreateUserRequestDto;
+import hous.server.service.user.dto.request.UpdateTestScoreRequestDto;
+import hous.server.service.user.dto.response.UpdatePersonalityColorResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles(value = "local")
+@Transactional
+public class BadgeServiceTest {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    TodoRepository todoRepository;
+
+    @Autowired
+    RuleRepository ruleRepository;
+
+    @Autowired
+    AcquireRepository acquireRepository;
+
+    @Autowired
+    BadgeRepository badgeRepository;
+
+    @Autowired
+    UserService userService;
+
+    @Autowired
+    RoomService roomService;
+
+    @Autowired
+    BadgeService badgeService;
+
+    @Autowired
+    TodoService todoService;
+
+    @Autowired
+    RuleService ruleService;
+
+    @Test
+    @DisplayName("두근두근 하우스 배지 획득")
+    public void acquire_badge_by_pounding_house_on_success() {
+        // given
+        CreateUserRequestDto createUserRequestDto = CreateUserRequestDto.of(
+                "socialId1", UserSocialType.KAKAO, "fcmToken1", "nickname1", "2022-01-01", true);
+        Long userId = userService.registerUser(createUserRequestDto);
+        User user = userRepository.findUserById(userId);
+        SetRoomNameRequestDto setRoomNameRequestDto = SetRoomNameRequestDto.of("room1");
+
+        // when
+        roomService.createRoom(setRoomNameRequestDto, userId);
+
+        // then
+        List<Acquire> acquires = acquireRepository.findAllAcquireByOnboarding(user.getOnboarding());
+        Acquire acquireBadge = acquires.stream()
+                .filter(acquire -> BadgeInfo.I_AM_SUCH_A_PERSON.equals(acquire.getBadge().getInfo()))
+                .findAny()
+                .orElse(null);
+        assertThat(acquires).hasSize(1);
+        assertThat(acquireBadge).isNotNull();
+    }
+
+    @Test
+    @DisplayName("나 이런 사람이야 배지 획득")
+    public void acquire_badge_by_i_am_such_a_person_on_success() {
+        // given
+        CreateUserRequestDto createUserRequestDto = CreateUserRequestDto.of(
+                "socialId1", UserSocialType.KAKAO, "fcmToken1", "nickname1", "2022-01-01", true);
+        Long userId = userService.registerUser(createUserRequestDto);
+        User user = userRepository.findUserById(userId);
+        SetRoomNameRequestDto setRoomNameRequestDto = SetRoomNameRequestDto.of("room1");
+        roomService.createRoom(setRoomNameRequestDto, userId);
+        UpdateTestScoreRequestDto updateTestScoreRequestDto = UpdateTestScoreRequestDto.of(3, 3, 3, 3, 3);
+
+        // when
+        UpdatePersonalityColorResponse updatePersonalityColorResponse = userService.updateUserTestScore(updateTestScoreRequestDto, user.getId());
+
+        // then
+        List<Acquire> acquires = acquireRepository.findAllAcquireByOnboarding(user.getOnboarding());
+        Acquire acquireBadge1 = acquires.stream()
+                .filter(acquire -> BadgeInfo.I_AM_SUCH_A_PERSON.equals(acquire.getBadge().getInfo()))
+                .findAny()
+                .orElse(null);
+        Acquire acquireBadge2 = acquires.stream()
+                .filter(acquire -> BadgeInfo.OUR_HOUSE_HOMIES.equals(acquire.getBadge().getInfo()))
+                .findAny()
+                .orElse(null);
+        assertThat(acquires).hasSize(3);
+        assertThat(acquireBadge1).isNotNull();
+        assertThat(acquireBadge2).isNotNull();
+        assertThat(updatePersonalityColorResponse.getColor()).isEqualTo(PersonalityColor.YELLOW);
+    }
+
+    @Test
+    @DisplayName("우리집 호미들 배지 획득")
+    public void acquire_badge_by_our_house_homies_on_success() {
+        // given
+        CreateUserRequestDto createUserRequestDto1 = CreateUserRequestDto.of(
+                "socialId1", UserSocialType.KAKAO, "fcmToken1", "nickname1", "2022-01-01", true);
+        CreateUserRequestDto createUserRequestDto2 = CreateUserRequestDto.of(
+                "socialId2", UserSocialType.KAKAO, "fcmToken2", "nickname2", "2022-01-01", true);
+        Long userId1 = userService.registerUser(createUserRequestDto1);
+        Long userId2 = userService.registerUser(createUserRequestDto2);
+        User user1 = userRepository.findUserById(userId1);
+        User user2 = userRepository.findUserById(userId2);
+        SetRoomNameRequestDto setRoomNameRequestDto = SetRoomNameRequestDto.of("room1");
+        RoomInfoResponse roomInfoResponse = roomService.createRoom(setRoomNameRequestDto, userId1);
+        roomService.joinRoom(roomInfoResponse.getRoomId(), userId2);
+        UpdateTestScoreRequestDto updateTestScoreRequestDto1 = UpdateTestScoreRequestDto.of(9, 9, 9, 9, 9);
+        UpdateTestScoreRequestDto updateTestScoreRequestDto2 = UpdateTestScoreRequestDto.of(9, 9, 9, 6, 6);
+
+        // when
+        UpdatePersonalityColorResponse updatePersonalityColorResponse1 = userService.updateUserTestScore(updateTestScoreRequestDto1, user1.getId());
+        UpdatePersonalityColorResponse updatePersonalityColorResponse2 = userService.updateUserTestScore(updateTestScoreRequestDto2, user2.getId());
+
+        // then
+        List<Acquire> acquiresByUser1 = acquireRepository.findAllAcquireByOnboarding(user1.getOnboarding());
+        List<Acquire> acquiresByUser2 = acquireRepository.findAllAcquireByOnboarding(user2.getOnboarding());
+        Acquire acquireBadge1 = acquiresByUser1.stream()
+                .filter(acquire -> BadgeInfo.OUR_HOUSE_HOMIES.equals(acquire.getBadge().getInfo()))
+                .findAny()
+                .orElse(null);
+        Acquire acquireBadge2 = acquiresByUser2.stream()
+                .filter(acquire -> BadgeInfo.OUR_HOUSE_HOMIES.equals(acquire.getBadge().getInfo()))
+                .findAny()
+                .orElse(null);
+        assertThat(acquiresByUser1).hasSize(3);
+        assertThat(acquiresByUser2).hasSize(3);
+        assertThat(acquireBadge1).isNotNull();
+        assertThat(acquireBadge2).isNotNull();
+        assertThat(updatePersonalityColorResponse1.getColor()).isEqualTo(PersonalityColor.GREEN);
+        assertThat(updatePersonalityColorResponse2.getColor()).isEqualTo(PersonalityColor.PURPLE);
+    }
+
+    @Test
+    @DisplayName("나도 날 모르겠어 배지 획득")
+    public void acquire_badge_by_i_dont_even_know_me_on_success() {
+        // given
+        CreateUserRequestDto createUserRequestDto = CreateUserRequestDto.of(
+                "socialId1", UserSocialType.KAKAO, "fcmToken1", "nickname1", "2022-01-01", true);
+        Long userId = userService.registerUser(createUserRequestDto);
+        User user = userRepository.findUserById(userId);
+        SetRoomNameRequestDto setRoomNameRequestDto = SetRoomNameRequestDto.of("room1");
+        roomService.createRoom(setRoomNameRequestDto, userId);
+
+        // when
+        UpdatePersonalityColorResponse updatePersonalityColorResponse = null;
+        for (int i = 0; i < 5; i++) {
+            int randomNumber = (int) ((Math.random() * 3) + 3); // 3 ~ 9 까지의 랜덤 숫자
+            updatePersonalityColorResponse = userService.updateUserTestScore(
+                    UpdateTestScoreRequestDto.of(randomNumber, randomNumber, randomNumber, randomNumber, randomNumber),
+                    userId
+            );
+        }
+        // then
+        List<Acquire> acquiresByUser = acquireRepository.findAllAcquireByOnboarding(user.getOnboarding());
+        Acquire acquireBadge = acquiresByUser.stream()
+                .filter(acquire -> BadgeInfo.I_DONT_EVEN_KNOW_ME.equals(acquire.getBadge().getInfo()))
+                .findAny()
+                .orElse(null);
+        assertThat(acquiresByUser).hasSize(4);
+        assertThat(acquireBadge).isNotNull();
+        assertThat(user.getOnboarding().getPersonality().getColor()).isEqualTo(updatePersonalityColorResponse.getColor());
+    }
+
+    @Test
+    @DisplayName("호미의 탄생 배지 획득")
+    public void acquire_badge_by_homie_is_born_on_success() {
+        // given
+        String now = DateUtils.todayLocalDateToString();
+        CreateUserRequestDto createUserRequestDto = CreateUserRequestDto.of(
+                "socialId1", UserSocialType.KAKAO, "fcmToken1", "nickname1", now, true);
+        Long userId = userService.registerUser(createUserRequestDto);
+        User user = userRepository.findUserById(userId);
+        SetRoomNameRequestDto setRoomNameRequestDto = SetRoomNameRequestDto.of("room1");
+        roomService.createRoom(setRoomNameRequestDto, userId);
+
+        // when
+        badgeService.acquireBadge(user, BadgeInfo.HOMIE_IS_BORN);
+
+        // then
+        List<Acquire> acquiresByUser = acquireRepository.findAllAcquireByOnboarding(user.getOnboarding());
+        Acquire acquireBadge = acquiresByUser.stream()
+                .filter(acquire -> BadgeInfo.HOMIE_IS_BORN.equals(acquire.getBadge().getInfo()))
+                .findAny()
+                .orElse(null);
+        assertThat(acquiresByUser).hasSize(2);
+        assertThat(acquireBadge).isNotNull();
+    }
+
+    @Test
+    @DisplayName("to-do 한 걸음 배지 획득")
+    public void acquire_badge_by_todo_one_step_on_success() {
+        // given
+        String now = DateUtils.todayLocalDateToString();
+        CreateUserRequestDto createUserRequestDto = CreateUserRequestDto.of(
+                "socialId1", UserSocialType.KAKAO, "fcmToken1", "nickname1", now, true);
+        Long userId = userService.registerUser(createUserRequestDto);
+        User user = userRepository.findUserById(userId);
+        SetRoomNameRequestDto setRoomNameRequestDto = SetRoomNameRequestDto.of("room1");
+        roomService.createRoom(setRoomNameRequestDto, userId);
+
+        // when
+        TodoInfoRequestDto todoInfoRequestDto = TodoInfoRequestDto.of("todo1", true,
+                List.of(TodoInfoRequestDto.TodoUser.builder()
+                        .onboardingId(user.getOnboarding().getId())
+                        .dayOfWeeks(List.of(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY))
+                        .build()));
+        todoService.createTodo(todoInfoRequestDto, userId);
+
+        // then
+        List<Todo> todos = todoRepository.findAll();
+        Todo todo = todos.stream().filter(t -> t.getName().equals("todo1")).findAny().orElse(null);
+        assertThat(todos).hasSize(1);
+        assertThat(todo).isNotNull();
+        List<Acquire> acquiresByUser = acquireRepository.findAllAcquireByOnboarding(user.getOnboarding());
+        Acquire acquireBadge = acquiresByUser.stream()
+                .filter(acquire -> BadgeInfo.TODO_ONE_STEP.equals(acquire.getBadge().getInfo()))
+                .findAny()
+                .orElse(null);
+        assertThat(acquiresByUser).hasSize(2);
+        assertThat(acquireBadge).isNotNull();
+    }
+
+    // TODO 참 잘했어요 배지 획득 테스트
+    // TODO 성실왕 호미 테스트
+    // TODO todo-마스터 테스트
+
+    @Test
+    @DisplayName("기둥을 세우자 배지 획득")
+    public void acquire_badge_by_lets_build_a_pole_on_success() {
+        // given
+        String now = DateUtils.todayLocalDateToString();
+        CreateUserRequestDto createUserRequestDto = CreateUserRequestDto.of(
+                "socialId1", UserSocialType.KAKAO, "fcmToken1", "nickname1", now, true);
+        Long userId = userService.registerUser(createUserRequestDto);
+        User user = userRepository.findUserById(userId);
+        SetRoomNameRequestDto setRoomNameRequestDto = SetRoomNameRequestDto.of("room1");
+        roomService.createRoom(setRoomNameRequestDto, userId);
+
+        // when
+        CreateRuleRequestDto createRuleRequestDto1 = CreateRuleRequestDto.of(List.of("rule1"));
+        ruleService.createRule(createRuleRequestDto1, userId);
+
+        // then
+        List<Acquire> acquiresByUser = acquireRepository.findAllAcquireByOnboarding(user.getOnboarding());
+        Acquire acquireBadge = acquiresByUser.stream()
+                .filter(acquire -> BadgeInfo.LETS_BUILD_A_POLE.equals(acquire.getBadge().getInfo()))
+                .findAny()
+                .orElse(null);
+        assertThat(acquiresByUser).hasSize(2);
+        assertThat(acquireBadge).isNotNull();
+    }
+
+    @Test
+    @DisplayName("우리집 기둥 호미 배지 획득")
+    public void acquire_badge_by_our_house_pillar_homie_on_success() {
+        // given
+        String now = DateUtils.todayLocalDateToString();
+        CreateUserRequestDto createUserRequestDto = CreateUserRequestDto.of(
+                "socialId1", UserSocialType.KAKAO, "fcmToken1", "nickname1", now, true);
+        Long userId = userService.registerUser(createUserRequestDto);
+        User user = userRepository.findUserById(userId);
+        SetRoomNameRequestDto setRoomNameRequestDto = SetRoomNameRequestDto.of("room1");
+        roomService.createRoom(setRoomNameRequestDto, userId);
+
+        // when
+        for (int i = 0; i < 5; i++) {
+            ruleService.createRule(CreateRuleRequestDto.of(List.of(String.valueOf(i))), userId);
+        }
+
+        // then
+        List<Rule> rules = ruleRepository.findAll();
+        IntStream.range(0, 5).mapToObj(index -> assertThat(rules.get(index).getName()).isEqualTo(index));
+        assertThat(rules).hasSize(5);
+        List<Acquire> acquiresByUser = acquireRepository.findAllAcquireByOnboarding(user.getOnboarding());
+        Acquire acquireBadge = acquiresByUser.stream()
+                .filter(acquire -> BadgeInfo.OUR_HOUSE_PILLAR_HOMIE.equals(acquire.getBadge().getInfo()))
+                .findAny()
+                .orElse(null);
+        assertThat(acquiresByUser).hasSize(3);
+        assertThat(acquireBadge).isNotNull();
+    }
+
+    @Test
+    @DisplayName("피드백 한걸음 배지 획득")
+    public void acquire_badge_by_feedback_one_step_on_success() {
+        // given
+        String now = DateUtils.todayLocalDateToString();
+        CreateUserRequestDto createUserRequestDto = CreateUserRequestDto.of(
+                "socialId1", UserSocialType.KAKAO, "fcmToken1", "nickname1", now, true);
+        Long userId = userService.registerUser(createUserRequestDto);
+        User user = userRepository.findUserById(userId);
+        SetRoomNameRequestDto setRoomNameRequestDto = SetRoomNameRequestDto.of("room1");
+        roomService.createRoom(setRoomNameRequestDto, userId);
+
+        // when
+        userService.acquireFeedbackBadge(userId);
+
+        // then
+        List<Acquire> acquiresByUser = acquireRepository.findAllAcquireByOnboarding(user.getOnboarding());
+        Acquire acquireBadge = acquiresByUser.stream()
+                .filter(acquire -> BadgeInfo.FEEDBACK_ONE_STEP.equals(acquire.getBadge().getInfo()))
+                .findAny()
+                .orElse(null);
+        assertThat(acquiresByUser).hasSize(2);
+        assertThat(acquireBadge).isNotNull();
+    }
+}

--- a/src/test/java/hous/server/service/badge/BadgeServiceUtilsTest.java
+++ b/src/test/java/hous/server/service/badge/BadgeServiceUtilsTest.java
@@ -45,7 +45,7 @@ public class BadgeServiceUtilsTest {
 
     @Test
     @DisplayName("배지 존재할 경우 true 를 반환")
-    public void hasBadge_exists_on_success() {
+    public void has_badge_exists_on_success() {
         // given
         CreateUserRequestDto createUserRequestDto = CreateUserRequestDto.of(
                 "socialId1", UserSocialType.KAKAO, "fcmToken1", "nickname1", "2022-01-01", true);
@@ -64,7 +64,7 @@ public class BadgeServiceUtilsTest {
 
     @Test
     @DisplayName("배지가 존재하지 않을 경우 false 를 반환")
-    public void hasBadge_un_exists_on_success() {
+    public void has_badge_unexists_on_success() {
         // given
         CreateUserRequestDto createUserRequestDto = CreateUserRequestDto.of(
                 "socialId1", UserSocialType.KAKAO, "fcmToken1", "nickname1", "2022-01-01", true);
@@ -83,7 +83,7 @@ public class BadgeServiceUtilsTest {
 
     @Test
     @DisplayName("존재하는 배지의 경우 배지를 반환")
-    public void findBadgeById_on_success() {
+    public void find_badge_by_id_on_success() {
         // given
         BadgeInfo testBadgeInfo = BadgeInfo.I_AM_SUCH_A_PERSON;
         Badge testBadge = badgeRepository.findBadgeByBadgeInfo(testBadgeInfo);
@@ -98,7 +98,7 @@ public class BadgeServiceUtilsTest {
 
     @Test
     @DisplayName("존재하지 않는 배지의 경우 404 예외 발생")
-    public void findBadgeById_by_not_found_exception() {
+    public void find_badge_by_id_throw_by_not_found_exception() {
         // given
         Long unExistsBadgeId = 50L;
 
@@ -112,7 +112,7 @@ public class BadgeServiceUtilsTest {
 
     @Test
     @DisplayName("사용자가 획득한 배지가 아니라면 403 예외 반환")
-    public void validateExistsByOnboardingAndBadge_by_forbidden_exception() {
+    public void validate_exists_by_onboarding_and_badge_throw_by_forbidden_exception() {
         // given
         CreateUserRequestDto createUserRequestDto = CreateUserRequestDto.of(
                 "socialId1", UserSocialType.KAKAO, "fcmToken1", "nickname1", "2022-01-01", true);

--- a/src/test/java/hous/server/service/badge/BadgeServiceUtilsTest.java
+++ b/src/test/java/hous/server/service/badge/BadgeServiceUtilsTest.java
@@ -1,0 +1,131 @@
+package hous.server.service.badge;
+
+import hous.server.common.exception.ForbiddenException;
+import hous.server.common.exception.NotFoundException;
+import hous.server.domain.badge.Badge;
+import hous.server.domain.badge.BadgeInfo;
+import hous.server.domain.badge.mysql.AcquireRepository;
+import hous.server.domain.badge.mysql.BadgeRepository;
+import hous.server.domain.user.User;
+import hous.server.domain.user.UserSocialType;
+import hous.server.domain.user.mysql.UserRepository;
+import hous.server.service.room.RoomService;
+import hous.server.service.room.dto.request.SetRoomNameRequestDto;
+import hous.server.service.user.UserService;
+import hous.server.service.user.dto.request.CreateUserRequestDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+@SpringBootTest
+@ActiveProfiles(value = "local")
+@Transactional
+public class BadgeServiceUtilsTest {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    AcquireRepository acquireRepository;
+
+    @Autowired
+    BadgeRepository badgeRepository;
+
+    @Autowired
+    UserService userService;
+
+    @Autowired
+    RoomService roomService;
+
+    @Test
+    @DisplayName("배지 존재할 경우 true 를 반환")
+    public void hasBadge_exists_on_success() {
+        // given
+        CreateUserRequestDto createUserRequestDto = CreateUserRequestDto.of(
+                "socialId1", UserSocialType.KAKAO, "fcmToken1", "nickname1", "2022-01-01", true);
+        Long userId = userService.registerUser(createUserRequestDto);
+        User user = userRepository.findUserById(userId);
+
+        SetRoomNameRequestDto setRoomNameRequestDto = SetRoomNameRequestDto.of("room1");
+        roomService.createRoom(setRoomNameRequestDto, userId);
+
+        // when
+        Boolean result = BadgeServiceUtils.hasBadge(badgeRepository, acquireRepository, BadgeInfo.POUNDING_HOUSE, user.getOnboarding());
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("배지가 존재하지 않을 경우 false 를 반환")
+    public void hasBadge_un_exists_on_success() {
+        // given
+        CreateUserRequestDto createUserRequestDto = CreateUserRequestDto.of(
+                "socialId1", UserSocialType.KAKAO, "fcmToken1", "nickname1", "2022-01-01", true);
+        Long userId = userService.registerUser(createUserRequestDto);
+        User user = userRepository.findUserById(userId);
+
+        SetRoomNameRequestDto setRoomNameRequestDto = SetRoomNameRequestDto.of("room1");
+        roomService.createRoom(setRoomNameRequestDto, userId);
+
+        // when
+        Boolean result = BadgeServiceUtils.hasBadge(badgeRepository, acquireRepository, BadgeInfo.I_AM_SUCH_A_PERSON, user.getOnboarding());
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("존재하는 배지의 경우 배지를 반환")
+    public void findBadgeById_on_success() {
+        // given
+        BadgeInfo testBadgeInfo = BadgeInfo.I_AM_SUCH_A_PERSON;
+        Badge testBadge = badgeRepository.findBadgeByBadgeInfo(testBadgeInfo);
+
+        // when
+        Badge resultBadge = BadgeServiceUtils.findBadgeById(badgeRepository, testBadge.getId());
+
+        // then
+        assertThat(resultBadge).isNotNull();
+        assertThat(resultBadge.getInfo()).isEqualTo(testBadgeInfo);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 배지의 경우 404 예외 발생")
+    public void findBadgeById_by_not_found_exception() {
+        // given
+        Long unExistsBadgeId = 50L;
+
+        // when then
+        String matchedExceptionMessage = String.format("존재하지 않는 badge (%s) 입니다", unExistsBadgeId);
+        assertThatThrownBy(() -> {
+            BadgeServiceUtils.findBadgeById(badgeRepository, unExistsBadgeId);
+        }).isInstanceOf(NotFoundException.class)
+                .hasMessageContaining(matchedExceptionMessage);
+    }
+
+    @Test
+    @DisplayName("사용자가 획득한 배지가 아니라면 403 예외 반환")
+    public void validateExistsByOnboardingAndBadge_by_forbidden_exception() {
+        // given
+        CreateUserRequestDto createUserRequestDto = CreateUserRequestDto.of(
+                "socialId1", UserSocialType.KAKAO, "fcmToken1", "nickname1", "2022-01-01", true);
+        Long userId = userService.registerUser(createUserRequestDto);
+        User user = userRepository.findUserById(userId);
+
+        Badge badge = badgeRepository.findBadgeByBadgeInfo(BadgeInfo.POUNDING_HOUSE);
+
+        // when then
+        String matchedExceptionMessage = String.format("유저가 (%s) 획득한 badge (%s) 가 아닙니다.", user.getOnboarding().getId(), badge.getId());
+        assertThatThrownBy(() -> {
+            BadgeServiceUtils.validateExistsByOnboardingAndBadge(acquireRepository, user.getOnboarding(), badge);
+        }).isInstanceOf(ForbiddenException.class)
+                .hasMessageContaining(matchedExceptionMessage);
+    }
+}

--- a/src/test/java/hous/server/service/todo/TodoServiceTest.java
+++ b/src/test/java/hous/server/service/todo/TodoServiceTest.java
@@ -122,9 +122,9 @@ public class TodoServiceTest {
     }
 
     @Test
-    @DisplayName("이미 존재하는 rule 과 같은 이름을 가진 rule 추가할 경우 409 예외 발생")
+    @DisplayName("이미 존재하는 todo 와 같은 이름을 가진 todo 추가할 경우 409 예외 발생")
     @Transactional
-    public void create_duplicate_rule_name_throw_by_conflict_exception() {
+    public void create_duplicate_todo_name_throw_by_conflict_exception() {
         // given
         CreateUserRequestDto createUserRequestDto = CreateUserRequestDto.of(
                 "socialId1", UserSocialType.KAKAO, "fcmToken1", "nickname1", "2022-01-01", true);


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #304

## 🔑 Key Changes

1. BadgeServiceUtils, BadgeService 테스트 코드 추가 후 테스트 수행
2. 기존 redis 에서 카운터 하는 로직 삭제
3. badgeCounter entity 수정
   - 기존에는 ~CompleteCount 라는 필드명을 가졌는데 확장성을 고려하여 countType / count 로 변경했습니다.
4. 배지 획득 시 카운트 하는 로직 badgeCounter로 수정
   - 수정 후 테스트 코드 변경하여 수행

## 📢 To Reviewers
- 우선 todo 관련 배지 중 스케줄러에 의해 획득되는 배지는 테스트가 어려운 상황입니다. (참 잘했어요, 성실왕 호미, 투두 마스터)
  - 체크를 월 / 화 / 수 / 목 / 금 / 토 / 일 을 모두 해주고, 스케줄러 함수를 7번, 14번, 21번 호출하는 식으로 테스트 하려고 했으나
  - 체크 내부 로직에서 오늘 날짜만 체크할 수 있도록 되어 있어서 테스트가 어려웠습니다 ..... 
  - 이 부분은 논의가 필요해 보이네요 ... ㅠㅛㅠ 좋은 방법이 있다면 말해주세요 .... 
    - 아쉬운대로 다른 카운트하여 획득하는 배지 (나도 날 잘 모르겠어, 우리집 기둥 호미) 미획득 시에 카운터 값을 확인하는 테스트 코드를 추가했습니다. 
- 기존에 카운터 로직의 if-else-if-else의 늪을 빠져나오고자 .... 로직을 변경하려고 했는데 잘 안되네요 ... 좋은 방법이 있다면 ..... 코리 부탁드립니다. .. ㅎㅎ 