### PR TITLE
알림 및 배지 카운터 데이터를 mongodb로 마이그레이션 하는 일회성 api 추가

### DIFF
--- a/hous-api/src/main/java/hous/api/controller/delete/MigrationController.java
+++ b/hous-api/src/main/java/hous/api/controller/delete/MigrationController.java
@@ -1,0 +1,37 @@
+package hous.api.controller.delete;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import hous.api.service.delete.MigrationService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+
+// TODO migration - 삭제 예정
+
+@Api(tags = "Migration")
+@RestController
+@RequestMapping("/migration")
+@RequiredArgsConstructor
+public class MigrationController {
+	private final MigrationService migrationService;
+
+	@ApiOperation(value = "[삭제될 api] redis 데이터 -> mongo db로 마이그레이션 하는 api.")
+	@DeleteMapping("/redis")
+	public ResponseEntity redisToMongoDb() {
+		int migrationDataCount = migrationService.transferRedisToMongoDb();
+		return ResponseEntity.ok(String.format("redis 카운터 데이터 (%s)개 전환 성공", migrationDataCount));
+	}
+
+	@ApiOperation(value = "[삭제될 api] 알림 데이터 -> mongo db로 마이그레이션 하는 api.")
+	@DeleteMapping("/notification")
+	public ResponseEntity notificationToMongoDb() {
+		List<Integer> successCount = migrationService.transferNotificationToMongoDb();
+		return ResponseEntity.ok(String.format("알림 데이터 (%s)개 중 (%s)개 전환 성공", successCount.get(0), successCount.get(1)));
+	}
+}

--- a/hous-api/src/main/java/hous/api/controller/delete/MigrationController.java
+++ b/hous-api/src/main/java/hous/api/controller/delete/MigrationController.java
@@ -24,8 +24,9 @@ public class MigrationController {
 	@ApiOperation(value = "[삭제될 api] redis 데이터 -> mongo db로 마이그레이션 하는 api.")
 	@DeleteMapping("/redis")
 	public ResponseEntity redisToMongoDb() {
-		int migrationDataCount = migrationService.transferRedisToMongoDb();
-		return ResponseEntity.ok(String.format("redis 카운터 데이터 (%s)개 전환 성공", migrationDataCount));
+		List<Integer> successCount = migrationService.transferRedisToMongoDb();
+		return ResponseEntity.ok(
+			String.format("redis 카운터 데이터 (%s)개 중 (%s)개 전환 성공", successCount.get(0), successCount.get(1)));
 	}
 
 	@ApiOperation(value = "[삭제될 api] 알림 데이터 -> mongo db로 마이그레이션 하는 api.")

--- a/hous-api/src/main/java/hous/api/service/delete/MigrationService.java
+++ b/hous-api/src/main/java/hous/api/service/delete/MigrationService.java
@@ -36,9 +36,10 @@ public class MigrationService {
 	private final RdbNotificationRepository rdbNotificationRepository;
 	private final NotificationRepository notificationRepository;
 
-	public int transferRedisToMongoDb() {
+	public List<Integer> transferRedisToMongoDb() {
 		// 전체 데이터를 가져와
 		Set<String> redisKeys = redisTemplate.keys("*");
+		int successCount = 0;
 		for (String key : redisKeys) {
 			Long userId = Long.parseLong(key.substring(key.indexOf(":") + 1));
 			// key 값에 따라 몽고디비에 저장해
@@ -46,19 +47,22 @@ public class MigrationService {
 				BadgeCounter personalityTestCounter = getBadgeCounterByCounterType(userId,
 					BadgeCounterType.TEST_SCORE_COMPLETE);
 				migrationBadgeCount(key, personalityTestCounter);
+				successCount++;
 			}
 
 			if (key.startsWith(CREATE_RULE_COUNT)) {
 				BadgeCounter ruleCounter = getBadgeCounterByCounterType(userId, BadgeCounterType.RULE_CREATE);
 				migrationBadgeCount(key, ruleCounter);
+				successCount++;
 			}
 
 			if (key.startsWith(TODO_COMPLETE_COUNT)) {
 				BadgeCounter todoCounter = getBadgeCounterByCounterType(userId, BadgeCounterType.TODO_COMPLETE);
 				migrationBadgeCount(key, todoCounter);
+				successCount++;
 			}
 		}
-		return redisKeys.size();
+		return List.of(redisKeys.size(), successCount);
 	}
 
 	private BadgeCounter getBadgeCounterByCounterType(Long userId, BadgeCounterType badgeCounterType) {

--- a/hous-api/src/main/java/hous/api/service/delete/MigrationService.java
+++ b/hous-api/src/main/java/hous/api/service/delete/MigrationService.java
@@ -1,0 +1,102 @@
+package hous.api.service.delete;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import hous.common.util.DateUtils;
+import hous.core.domain.badge.BadgeCounter;
+import hous.core.domain.badge.BadgeCounterType;
+import hous.core.domain.badge.mongo.BadgeCounterRepository;
+import hous.core.domain.delete.RdbNotification;
+import hous.core.domain.delete.mysql.RdbNotificationRepository;
+import hous.core.domain.notification.Notification;
+import hous.core.domain.notification.mongo.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+
+// TODO migration - 삭제 예정
+
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class MigrationService {
+
+	public static final String PERSONALITY_TEST_COUNT = "PTC:";
+	public static final String CREATE_RULE_COUNT = "CRC:";
+	public static final String TODO_COMPLETE_COUNT = "TCC:";
+
+	private final RedisTemplate<String, Object> redisTemplate;
+
+	private final BadgeCounterRepository badgeCounterRepository;
+	private final RdbNotificationRepository rdbNotificationRepository;
+	private final NotificationRepository notificationRepository;
+
+	public int transferRedisToMongoDb() {
+		// 전체 데이터를 가져와
+		Set<String> redisKeys = redisTemplate.keys("*");
+		for (String key : redisKeys) {
+			Long userId = Long.parseLong(key.substring(key.indexOf(":") + 1));
+			// key 값에 따라 몽고디비에 저장해
+			if (key.startsWith(PERSONALITY_TEST_COUNT)) {
+				BadgeCounter personalityTestCounter = getBadgeCounterByCounterType(userId,
+					BadgeCounterType.TEST_SCORE_COMPLETE);
+				migrationBadgeCount(key, personalityTestCounter);
+			}
+
+			if (key.startsWith(CREATE_RULE_COUNT)) {
+				BadgeCounter ruleCounter = getBadgeCounterByCounterType(userId, BadgeCounterType.RULE_CREATE);
+				migrationBadgeCount(key, ruleCounter);
+			}
+
+			if (key.startsWith(TODO_COMPLETE_COUNT)) {
+				BadgeCounter todoCounter = getBadgeCounterByCounterType(userId, BadgeCounterType.TODO_COMPLETE);
+				migrationBadgeCount(key, todoCounter);
+			}
+		}
+		return redisKeys.size();
+	}
+
+	private BadgeCounter getBadgeCounterByCounterType(Long userId, BadgeCounterType badgeCounterType) {
+		BadgeCounter badgeCounter = badgeCounterRepository.findByUserIdAndCountType(userId, badgeCounterType);
+		if (badgeCounter == null) {
+			badgeCounter = badgeCounterRepository.save(BadgeCounter.newInstance(userId, badgeCounterType, 0));
+		}
+		return badgeCounter;
+	}
+
+	private void migrationBadgeCount(String redisKey, BadgeCounter badgeCounter) {
+		String count = (String)redisTemplate.opsForValue().get(redisKey);
+		if (count != null) {
+			badgeCounter.updateCount(Integer.parseInt(count));
+			badgeCounterRepository.save(badgeCounter);
+			redisTemplate.delete(redisKey);
+		}
+	}
+
+	public List<Integer> transferNotificationToMongoDb() {
+		List<RdbNotification> rdbNotifications = rdbNotificationRepository.findAllByOrderByIdAsc();
+		LocalDateTime twentyEightDaysAgo = DateUtils.todayLocalDateTime().minusDays(28);
+		AtomicInteger successCount = new AtomicInteger();
+		rdbNotifications.stream()
+			// 28일이 이미 지난 데이터는 건너뛰셈
+			.filter(rdbNotification -> rdbNotification.getCreatedAt().isAfter(twentyEightDaysAgo))
+			.forEach(rdbNotification -> {
+				// 생성시간 그대로 저장해야함 수정시간도 저장
+				// 사라질 시간은 오늘 기준 30일 전
+				Notification notification = Notification.migrationInstance(rdbNotification.getId(),
+					rdbNotification.getOnboarding().getId(),
+					rdbNotification.getType(), rdbNotification.getContent(), rdbNotification.isRead(),
+					rdbNotification.getCreatedAt());
+				notification.setCreatedAt(rdbNotification.getCreatedAt());
+				notification.setUpdatedAt(rdbNotification.getUpdatedAt());
+				notificationRepository.save(notification);
+				successCount.getAndIncrement();
+			});
+		return List.of(rdbNotifications.size(), successCount.get());
+	}
+}

--- a/hous-api/src/main/java/hous/api/service/notification/dto/response/NotificationInfo.java
+++ b/hous-api/src/main/java/hous/api/service/notification/dto/response/NotificationInfo.java
@@ -33,13 +33,12 @@ public class NotificationInfo {
 	}
 
 	public static NotificationInfo of(Notification notification, LocalDateTime now) {
-		NotificationInfo notificationInfo = NotificationInfo.builder()
+		return NotificationInfo.builder()
 			.notificationId(notification.getId())
 			.type(notification.getType())
 			.content(notification.getContent())
 			.isRead(notification.isRead())
-			.createdAt(DateUtils.passedTime(now, notification.getCreatedAt()))
+			.createdAt(DateUtils.passedTime(now, DateUtils.convertUtcToKst(notification.getCreatedAt())))
 			.build();
-		return notificationInfo;
 	}
 }

--- a/hous-api/src/test/java/hous/api/service/migration/MigrationDataTest.java
+++ b/hous-api/src/test/java/hous/api/service/migration/MigrationDataTest.java
@@ -1,0 +1,113 @@
+package hous.api.service.migration;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import hous.api.service.delete.MigrationService;
+import hous.api.service.user.UserService;
+import hous.api.service.user.dto.request.CreateUserRequestDto;
+import hous.core.domain.badge.BadgeCounter;
+import hous.core.domain.badge.BadgeCounterType;
+import hous.core.domain.badge.mongo.BadgeCounterRepository;
+import hous.core.domain.delete.mysql.RdbNotificationRepository;
+import hous.core.domain.notification.mongo.NotificationRepository;
+import hous.core.domain.user.UserSocialType;
+
+// TODO migration - 삭제 예정
+
+@SpringBootTest
+@ActiveProfiles(value = "local")
+@Transactional
+public class MigrationDataTest {
+
+	public static final String PERSONALITY_TEST_COUNT = "PTC:";
+	public static final String CREATE_RULE_COUNT = "CRC:";
+	public static final String TODO_COMPLETE_COUNT = "TCC:";
+
+	@Autowired
+	private UserService userService;
+
+	@Autowired
+	private MigrationService migrationService;
+
+	@Autowired
+	private RedisTemplate<String, Object> redisTemplate;
+
+	@Autowired
+	private BadgeCounterRepository badgeCounterRepository;
+
+	@Autowired
+	private NotificationRepository notificationRepository;
+	@Autowired
+	private RdbNotificationRepository rdbNotificationRepository;
+
+	@BeforeEach
+	public void init() {
+		badgeCounterRepository.deleteAll();
+	}
+
+	@Test
+	@DisplayName("redis에 저장된 데이터를 mongodb로 전환 확인")
+	public void transfer_redis_to_mongo_db() {
+		// given
+		CreateUserRequestDto createUserRequestDto1 = CreateUserRequestDto.of(
+			"socialId1", UserSocialType.KAKAO, "fcmToken1", "nickname1", "2022-01-01", true);
+		Long userId1 = userService.registerUser(createUserRequestDto1);
+
+		CreateUserRequestDto createUserRequestDto2 = CreateUserRequestDto.of(
+			"socialId2", UserSocialType.KAKAO, "fcmToken2", "nickname2", "2022-01-01", true);
+		Long userId2 = userService.registerUser(createUserRequestDto2);
+
+		redisTemplate.opsForValue().set(PERSONALITY_TEST_COUNT + userId1, Integer.toString(3));
+		redisTemplate.opsForValue().set(PERSONALITY_TEST_COUNT + userId2, Integer.toString(2));
+		redisTemplate.opsForValue().set(CREATE_RULE_COUNT + userId1, Integer.toString(2));
+		redisTemplate.opsForValue().set(CREATE_RULE_COUNT + userId2, Integer.toString(1));
+		redisTemplate.opsForValue().set(TODO_COMPLETE_COUNT + userId1, Integer.toString(4));
+		redisTemplate.opsForValue().set(TODO_COMPLETE_COUNT + userId2, Integer.toString(2));
+
+		// when
+		migrationService.transferRedisToMongoDb();
+		Set<String> redisKeys = redisTemplate.keys("*");
+
+		// then
+		BadgeCounter testScoreCounterByUser1 = badgeCounterRepository.findByUserIdAndCountType(userId1,
+			BadgeCounterType.TEST_SCORE_COMPLETE);
+		BadgeCounter ruleCounterByUser1 = badgeCounterRepository.findByUserIdAndCountType(userId1,
+			BadgeCounterType.RULE_CREATE);
+		BadgeCounter todoCounterByUser1 = badgeCounterRepository.findByUserIdAndCountType(userId1,
+			BadgeCounterType.TODO_COMPLETE);
+
+		assertThat(testScoreCounterByUser1).isNotNull();
+		assertThat(testScoreCounterByUser1.getCount()).isEqualTo(3);
+		assertThat(ruleCounterByUser1).isNotNull();
+		assertThat(ruleCounterByUser1.getCount()).isEqualTo(2);
+		assertThat(todoCounterByUser1).isNotNull();
+		assertThat(todoCounterByUser1.getCount()).isEqualTo(4);
+
+		BadgeCounter testScoreCounterByUser2 = badgeCounterRepository.findByUserIdAndCountType(userId2,
+			BadgeCounterType.TEST_SCORE_COMPLETE);
+		BadgeCounter ruleCounterByUser2 = badgeCounterRepository.findByUserIdAndCountType(userId2,
+			BadgeCounterType.RULE_CREATE);
+		BadgeCounter todoCounterByUser2 = badgeCounterRepository.findByUserIdAndCountType(userId2,
+			BadgeCounterType.TODO_COMPLETE);
+
+		assertThat(testScoreCounterByUser2).isNotNull();
+		assertThat(testScoreCounterByUser2.getCount()).isEqualTo(2);
+		assertThat(ruleCounterByUser2).isNotNull();
+		assertThat(ruleCounterByUser2.getCount()).isEqualTo(1);
+		assertThat(todoCounterByUser2).isNotNull();
+		assertThat(todoCounterByUser2.getCount()).isEqualTo(2);
+
+		assertThat(redisKeys).isEmpty();
+	}
+}

--- a/hous-common/src/main/java/hous/common/util/DateUtils.java
+++ b/hous-common/src/main/java/hous/common/util/DateUtils.java
@@ -28,6 +28,10 @@ public class DateUtils {
 		return LocalDateTime.now(ZoneId.of("Asia/Seoul"));
 	}
 
+	public static LocalDateTime convertUtcToKst(LocalDateTime utcDateTime) {
+		return utcDateTime.plusHours(9);
+	}
+
 	public static LocalDate yesterdayLocalDate() {
 		LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
 		return today.minusDays(1);

--- a/hous-core/src/main/java/hous/core/domain/common/AuditingTimeEntity.java
+++ b/hous-core/src/main/java/hous/core/domain/common/AuditingTimeEntity.java
@@ -26,6 +26,8 @@ public class AuditingTimeEntity {
 	@Field(name = "created_at")
 	private LocalDateTime createdAt;
 
+	// TODO migration - setter 삭제할
+	@Setter
 	@LastModifiedDate
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", timezone = "Asia/Seoul")
 	@Field(name = "updated_at")

--- a/hous-core/src/main/java/hous/core/domain/delete/RdbNotification.java
+++ b/hous-core/src/main/java/hous/core/domain/delete/RdbNotification.java
@@ -1,0 +1,63 @@
+package hous.core.domain.delete;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+import hous.core.domain.common.AuditingTimeEntity;
+import hous.core.domain.notification.NotificationType;
+import hous.core.domain.user.Onboarding;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+// TODO migration 엔티티 - 삭제 예정
+
+@Getter
+@Entity(name = "notification")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class RdbNotification extends AuditingTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "onboarding_id")
+	private Onboarding onboarding;
+
+	@Column(nullable = false, length = 30)
+	@Enumerated(EnumType.STRING)
+	private NotificationType type;
+
+	@Column(nullable = false, length = 100)
+	private String content;
+
+	@Column(nullable = false)
+	private boolean isRead;
+
+	public static RdbNotification newInstance(Onboarding onboarding, NotificationType type, String content,
+		boolean isRead) {
+		return RdbNotification.builder()
+			.onboarding(onboarding)
+			.type(type)
+			.content(content)
+			.isRead(isRead)
+			.build();
+	}
+
+	public void updateIsRead() {
+		this.isRead = true;
+	}
+}

--- a/hous-core/src/main/java/hous/core/domain/delete/mysql/RdbNotificationRepository.java
+++ b/hous-core/src/main/java/hous/core/domain/delete/mysql/RdbNotificationRepository.java
@@ -1,0 +1,15 @@
+package hous.core.domain.delete.mysql;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import hous.core.domain.delete.RdbNotification;
+
+// TODO migration - 삭제 예정
+
+@Repository
+public interface RdbNotificationRepository extends JpaRepository<RdbNotification, Long> {
+	List<RdbNotification> findAllByOrderByIdAsc();
+}

--- a/hous-core/src/main/java/hous/core/domain/notification/Notification.java
+++ b/hous-core/src/main/java/hous/core/domain/notification/Notification.java
@@ -42,7 +42,7 @@ public class Notification extends AuditingTimeEntity {
 	@Field(name = "is_read")
 	private boolean isRead;
 
-	@Indexed(name = "notification_ttl", expireAfterSeconds = 60 * 60 * 24 * 30)
+	@Indexed(name = "notification_ttl", expireAfterSeconds = 0)
 	private LocalDateTime expireAt;
 
 	public static Notification newInstance(Long onboardingId, NotificationType type, String content, boolean isRead) {
@@ -51,7 +51,21 @@ public class Notification extends AuditingTimeEntity {
 			.type(type)
 			.content(content)
 			.isRead(isRead)
-			.expireAt(LocalDateTime.now())
+			.expireAt(LocalDateTime.now().plusDays(30))
+			.build();
+	}
+
+	// TODO migration - 삭제 예정
+
+	public static Notification migrationInstance(Long id, Long onboardingId, NotificationType type, String content,
+		boolean isRead, LocalDateTime createdAt) {
+		return builder()
+			.id(id)
+			.onboardingId(onboardingId)
+			.type(type)
+			.content(content)
+			.isRead(isRead)
+			.expireAt(createdAt.plusDays(30))
 			.build();
 	}
 


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #315 

## 🔑 Key Changes

1. 알림 및 배지 카운터 데이터를 mongodb로 마이그레이션 하는 일회성 api 추가
2. 추후 삭제가 필요한 부분에 TODO 주석을 추가

## 📢 To Reviewers
- redis 데이터의 경우 테스트코드를 작성해서 정상적으로 전환되는 것을 확인했습니다.
- 알림 데이터의 경우 경우 현재 dev 서버에 이는 notification 데이터의 일부에 createAt을 변경하여 데이터를 전환하는 테스트를 진행했습니다.
