### PR TITLE
#344 [fix] 규칙 메인 조회에서 대표 규칙 여부 함께 전달하도록 수정

### DIFF
--- a/hous-api/src/main/java/hous/api/service/rule/dto/response/RulesResponse.java
+++ b/hous-api/src/main/java/hous/api/service/rule/dto/response/RulesResponse.java
@@ -36,10 +36,14 @@ public class RulesResponse {
 	private static class RuleInfo {
 
 		private Long id;
-
 		private String name;
-
 		private boolean isNew;
+		private boolean isRepresent;
+
+		@JsonProperty("isRepresent")
+		public boolean isRepresent() {
+			return isRepresent;
+		}
 
 		private String createdAt;
 
@@ -53,6 +57,7 @@ public class RulesResponse {
 				.id(rule.getId())
 				.name(rule.getName())
 				.isNew(now.isBefore(rule.getCreatedAt().plusHours(12)))
+				.isRepresent(rule.isRepresent())
 				.createdAt(rule.getCreatedAt().toString())
 				.build();
 		}


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #344 

## 🔑 Key Changes

1. 규칙 메인 조회에서 대표 규칙 여부 함께 전달하도록 수정했습니다.

## 📢 To Reviewers
- 정렬은 기존에 compareTo 가 createAt 로 하도록 수정했었고, 대표 규칙 여부만 전달이 빠져있어서 추가했습니다~
