### PR TITLE
#344 [fix] 규칙 메인 조회에서 대표 규칙 여부 함께 전달하도록 수정

### DIFF
--- a/hous-api/src/main/java/hous/api/service/rule/dto/response/RulesResponse.java
+++ b/hous-api/src/main/java/hous/api/service/rule/dto/response/RulesResponse.java
@@ -36,11 +36,9 @@ public class RulesResponse {
 	private static class RuleInfo {
 
 		private Long id;
-
 		private String name;
-
 		private boolean isNew;
-
+		private boolean isRepresent;
 		private String createdAt;
 
 		@JsonProperty("isNew")
@@ -48,11 +46,17 @@ public class RulesResponse {
 			return isNew;
 		}
 
+		@JsonProperty("isRepresent")
+		public boolean isRepresent() {
+			return isRepresent;
+		}
+
 		public static RuleInfo of(Rule rule, LocalDateTime now) {
 			return RuleInfo.builder()
 				.id(rule.getId())
 				.name(rule.getName())
 				.isNew(now.isBefore(rule.getCreatedAt().plusHours(12)))
+				.isRepresent(rule.isRepresent())
 				.createdAt(rule.getCreatedAt().toString())
 				.build();
 		}

--- a/hous-api/src/main/java/hous/api/service/rule/dto/response/RulesResponse.java
+++ b/hous-api/src/main/java/hous/api/service/rule/dto/response/RulesResponse.java
@@ -1,10 +1,9 @@
 package hous.api.service.rule.dto.response;
 
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -25,18 +24,13 @@ public class RulesResponse {
 	private List<RuleInfo> rules;
 
 	public static RulesResponse of(List<Rule> rules, LocalDateTime now) {
-		List<RuleInfo> sortedRuleInfo = rules.stream()
-			.sorted(Rule::compareTo)
-			.map(rule -> RuleInfo.of(rule, now)).collect(Collectors.toList());
-
-		Map<Boolean, List<RuleInfo>> ruleInfoMap = sortedRuleInfo.stream()
-			.collect(Collectors.partitioningBy(RuleInfo::isRepresent));
-
-		List<RuleInfo> representRuleInfo = ruleInfoMap.get(true);
-		List<RuleInfo> nonRepresentRuleInfo = ruleInfoMap.get(false);
-
 		return RulesResponse.builder()
-			.rules(Stream.concat(representRuleInfo.stream(), nonRepresentRuleInfo.stream())
+			.rules(rules.stream()
+				.sorted(Rule::compareTo)
+				.map(rule -> RuleInfo.of(rule, now))
+				.collect(Collectors.toList())
+				.stream()
+				.sorted(Comparator.comparing(RuleInfo::isRepresent).reversed())
 				.collect(Collectors.toList()))
 			.build();
 	}

--- a/hous-api/src/main/java/hous/api/service/rule/dto/response/RulesResponse.java
+++ b/hous-api/src/main/java/hous/api/service/rule/dto/response/RulesResponse.java
@@ -2,7 +2,9 @@ package hous.api.service.rule.dto.response;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -23,10 +25,19 @@ public class RulesResponse {
 	private List<RuleInfo> rules;
 
 	public static RulesResponse of(List<Rule> rules, LocalDateTime now) {
+		List<RuleInfo> sortedRuleInfo = rules.stream()
+			.sorted(Rule::compareTo)
+			.map(rule -> RuleInfo.of(rule, now)).collect(Collectors.toList());
+
+		Map<Boolean, List<RuleInfo>> ruleInfoMap = sortedRuleInfo.stream()
+			.collect(Collectors.partitioningBy(RuleInfo::isRepresent));
+
+		List<RuleInfo> representRuleInfo = ruleInfoMap.get(true);
+		List<RuleInfo> nonRepresentRuleInfo = ruleInfoMap.get(false);
+
 		return RulesResponse.builder()
-			.rules(rules.stream()
-				.sorted(Rule::compareTo)
-				.map(rule -> RuleInfo.of(rule, now)).collect(Collectors.toList()))
+			.rules(Stream.concat(representRuleInfo.stream(), nonRepresentRuleInfo.stream())
+				.collect(Collectors.toList()))
 			.build();
 	}
 


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #344 

## 🔑 Key Changes

1. 규칙 메인 조회에서 대표 규칙 여부 함께 전달하도록 수정했습니다.

## 📢 To Reviewers
- 정렬은 수정할 사항이 없고, 대표 규칙 여부만 전달이 빠져있어서 추가했습니다~