### PR TITLE
#343 [fix] 대표규칙 룰 설정 api 수정

### DIFF
--- a/hous-api/src/main/java/hous/api/controller/rule/RuleController.java
+++ b/hous-api/src/main/java/hous/api/controller/rule/RuleController.java
@@ -268,8 +268,8 @@ public class RuleController {
 		@ApiResponse(code = 200, message = "성공입니다."),
 		@ApiResponse(
 			code = 400,
-			message = "1. 규칙 리스트를 입력해주세요. (rulesIdList)\n"
-				+ "2. 규칙 리스트는 빈 배열을 보낼 수 없습니다. (rulesIdList)",
+			message = "1. 규칙 리스트를 입력해주세요. (rules)\n"
+				+ "2. 규칙 리스트는 빈 배열을 보낼 수 없습니다. (rules)",
 			response = ErrorResponse.class),
 		@ApiResponse(code = 401, message = "토큰이 만료되었습니다. 다시 로그인 해주세요.", response = ErrorResponse.class),
 		@ApiResponse(code = 403, message = "대표 rule 은 3개를 초과할 수 없습니다.", response = ErrorResponse.class),

--- a/hous-api/src/main/java/hous/api/service/rule/RuleService.java
+++ b/hous-api/src/main/java/hous/api/service/rule/RuleService.java
@@ -30,6 +30,7 @@ import hous.api.service.rule.dto.request.UpdateRuleRepresentRequestDto;
 import hous.api.service.rule.dto.request.UpdateRuleRequestDto;
 import hous.api.service.rule.dto.response.RuleInfo;
 import hous.api.service.user.UserServiceUtils;
+import hous.common.constant.Constraint;
 import hous.common.exception.ConflictException;
 import hous.common.exception.ForbiddenException;
 import hous.common.type.FileType;
@@ -225,8 +226,9 @@ public class RuleService {
 		Room room = RoomServiceUtils.findParticipatingRoom(user);
 
 		Set<Long> ruleIds = new HashSet<>(request.getRules());
-		if (ruleIds.size() > 3) {
-			throw new ForbiddenException(String.format("방 (%s) 의 대표 rule 는 3 개를 초과할 수 없습니다.", room.getId()),
+		if (ruleIds.size() > Constraint.RULE_REPRESENT_MAX) {
+			throw new ForbiddenException(
+				String.format("방 (%s) 의 대표 rule 는 %s 개를 초과할 수 없습니다.", room.getId(), Constraint.RULE_REPRESENT_MAX),
 				FORBIDDEN_REPRESENT_RULE_COUNT_EXCEPTION);
 		}
 		room.getRules().forEach(rule -> rule.updateRuleRepresent(ruleIds.contains(rule.getId())));

--- a/hous-api/src/main/java/hous/api/service/rule/dto/request/UpdateRuleRepresentRequestDto.java
+++ b/hous-api/src/main/java/hous/api/service/rule/dto/request/UpdateRuleRepresentRequestDto.java
@@ -15,17 +15,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UpdateRuleRepresentRequestDto {
 
-	@ApiModelProperty(value = "수정된 규칙 리스트")
+	@ApiModelProperty(value = "설정한 대표 규칙 id 리스트", example = "[1, 2, 3]")
 	@NotNull(message = "{rule.list.notNull}")
 	@Size(min = Constraint.RULE_LIST_MIN, message = "{rule.list.min}")
-	private List<RepresentInfo> rules;
-
-	@Getter
-	@NoArgsConstructor(access = AccessLevel.PROTECTED)
-	public static class RepresentInfo {
-		@NotNull
-		private Long id;
-		@NotNull
-		private Boolean isPresent;
-	}
+	private List<Long> rules;
 }

--- a/hous-api/src/main/java/hous/api/service/rule/dto/response/RuleRepresentResponse.java
+++ b/hous-api/src/main/java/hous/api/service/rule/dto/response/RuleRepresentResponse.java
@@ -1,5 +1,6 @@
 package hous.api.service.rule.dto.response;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -21,10 +22,15 @@ public class RuleRepresentResponse {
 	private List<RuleInfo> rules;
 
 	public static RuleRepresentResponse of(List<Rule> rules) {
+
 		return RuleRepresentResponse.builder()
 			.rules(rules.stream()
 				.sorted(Rule::compareTo)
-				.map(RuleInfo::of).collect(Collectors.toList()))
+				.map(RuleInfo::of)
+				.collect(Collectors.toList())
+				.stream()
+				.sorted(Comparator.comparing(RuleInfo::isRepresent).reversed())
+				.collect(Collectors.toList()))
 			.build();
 	}
 


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #343

## 🔑 Key Changes

1. 대표규칙 룰 설정 api dto 및 내부 로직 수정 (id 만 받아서 모두 false 하고, 받은 id 만 true 로 저장되도록 수정했습니다.)

## 📢 To Reviewers
- 이렇게 작업하라는 의도의 이슈였던 것 같은데 맞을까요?! 
