### PR TITLE
피드백 관련 API 수정 및 통합

### DIFF
--- a/hous-api/src/main/java/hous/api/controller/user/UserController.java
+++ b/hous-api/src/main/java/hous/api/controller/user/UserController.java
@@ -22,7 +22,7 @@ import hous.api.service.user.dto.request.DeleteUserRequestDto;
 import hous.api.service.user.dto.request.UpdatePushSettingRequestDto;
 import hous.api.service.user.dto.request.UpdateTestScoreRequestDto;
 import hous.api.service.user.dto.request.UpdateUserInfoRequestDto;
-import hous.api.service.user.dto.request.UserDeleteFeedbackRequestDto;
+import hous.api.service.user.dto.request.UserFeedbackRequestDto;
 import hous.api.service.user.dto.response.UpdatePersonalityColorResponse;
 import hous.common.dto.ErrorResponse;
 import hous.common.dto.SuccessResponse;
@@ -260,7 +260,7 @@ public class UserController {
 	@Auth
 	@PostMapping("/v1/user/delete/feedback")
 	public ResponseEntity<SuccessResponse<String>> sendUserDeleteFeedback(@ApiIgnore @UserId Long userId,
-		@Valid @RequestBody UserDeleteFeedbackRequestDto request) {
+		@Valid @RequestBody UserFeedbackRequestDto request) {
 		userService.sendUserDeleteFeedback(request);
 		return SuccessResponse.OK;
 	}

--- a/hous-api/src/main/java/hous/api/controller/user/UserController.java
+++ b/hous-api/src/main/java/hous/api/controller/user/UserController.java
@@ -194,11 +194,18 @@ public class UserController {
 	}
 
 	@ApiOperation(
-		value = "[인증] 마이 페이지(설정) - 피드백 보내기 버튼 클릭 시 피드백 한걸음 배지를 전달 받습니다.",
-		notes = "배지는 푸시알림으로 전달합니다."
+		value = "[인증] 마이 페이지(설정) / 탈퇴 피드백 페이지 - 호미나라 피드백 보내기 혹은 탈퇴 피드백을 보냅니다.",
+		notes = "내용이 존재할 경우에만 호출해주세요.\n"
+			+ "피드백은 슬랙 알림으로 전달합니다.\n"
+			+ "호미나라 피드백 보내기의 경우 isDeleting = false,\n"
+			+ "탈퇴 피드백의 경우 isDeleting = true 를 보내주세요."
 	)
 	@ApiResponses(value = {
 		@ApiResponse(code = 200, message = "성공입니다."),
+		@ApiResponse(code = 400,
+			message = "1. 의견을 입력해주세요. (comment)\n"
+				+ "2. 의견은 200 글자 이내로 입력해주세요. (comment)",
+			response = ErrorResponse.class),
 		@ApiResponse(code = 401, message = "토큰이 만료되었습니다. 다시 로그인 해주세요.", response = ErrorResponse.class),
 		@ApiResponse(code = 404,
 			message = "1. 탈퇴했거나 존재하지 않는 유저입니다.\n"
@@ -212,8 +219,9 @@ public class UserController {
 	@Version
 	@Auth
 	@PostMapping("/v1/user/feedback")
-	public ResponseEntity<SuccessResponse<String>> acquireFeedbackBadge(@ApiIgnore @UserId Long userId) {
-		userService.acquireFeedbackBadge(userId);
+	public ResponseEntity<SuccessResponse<String>> sendUserFeedback(@ApiIgnore @UserId Long userId,
+		@Valid @RequestBody UserFeedbackRequestDto request) {
+		userService.sendUserFeedback(userId, request);
 		return SuccessResponse.OK;
 	}
 
@@ -236,32 +244,6 @@ public class UserController {
 	@DeleteMapping("/v2/user")
 	public ResponseEntity<SuccessResponse<String>> deleteUser(@ApiIgnore @UserId Long userId) {
 		userService.deleteUser(userId);
-		return SuccessResponse.OK;
-	}
-
-	@ApiOperation(
-		value = "[인증] 탈퇴 피드백 페이지 - 탈퇴 피드백을 보냅니다.",
-		notes = "내용이 존재할 경우에만 호출해주세요.\n"
-			+ "피드백은 슬랙 알림으로 전달합니다."
-	)
-	@ApiResponses(value = {
-		@ApiResponse(code = 200, message = "성공입니다."),
-		@ApiResponse(code = 400,
-			message = "1. 의견을 입력해주세요. (comment)\n"
-				+ "2. 의견은 200 글자 이내로 입력해주세요. (comment)",
-			response = ErrorResponse.class),
-		@ApiResponse(code = 401, message = "토큰이 만료되었습니다. 다시 로그인 해주세요.", response = ErrorResponse.class),
-		@ApiResponse(code = 409, message = "처리중인 요청입니다.", response = ErrorResponse.class),
-		@ApiResponse(code = 426, message = "최신 버전으로 업그레이드가 필요합니다.", response = ErrorResponse.class),
-		@ApiResponse(code = 500, message = "예상치 못한 서버 에러가 발생하였습니다.", response = ErrorResponse.class)
-	})
-	@PreventDuplicateRequest
-	@Version
-	@Auth
-	@PostMapping("/v1/user/delete/feedback")
-	public ResponseEntity<SuccessResponse<String>> sendUserDeleteFeedback(@ApiIgnore @UserId Long userId,
-		@Valid @RequestBody UserFeedbackRequestDto request) {
-		userService.sendUserDeleteFeedback(request);
 		return SuccessResponse.OK;
 	}
 }

--- a/hous-api/src/main/java/hous/api/service/user/UserService.java
+++ b/hous-api/src/main/java/hous/api/service/user/UserService.java
@@ -15,9 +15,9 @@ import hous.api.service.user.dto.request.DeleteUserRequestDto;
 import hous.api.service.user.dto.request.UpdatePushSettingRequestDto;
 import hous.api.service.user.dto.request.UpdateTestScoreRequestDto;
 import hous.api.service.user.dto.request.UpdateUserInfoRequestDto;
-import hous.api.service.user.dto.request.UserDeleteFeedbackRequestDto;
+import hous.api.service.user.dto.request.UserFeedbackRequestDto;
 import hous.api.service.user.dto.response.UpdatePersonalityColorResponse;
-import hous.common.dto.sqs.SlackUserDeleteFeedbackDto;
+import hous.common.dto.sqs.SlackUserFeedbackDto;
 import hous.common.util.JwtUtils;
 import hous.core.domain.badge.Badge;
 import hous.core.domain.badge.BadgeCounter;
@@ -212,8 +212,8 @@ public class UserService {
 		userRepository.delete(user);
 	}
 
-	public void sendUserDeleteFeedback(UserDeleteFeedbackRequestDto request) {
+	public void sendUserDeleteFeedback(UserFeedbackRequestDto request) {
 		feedbackRepository.save(Feedback.newInstance(request.getComment()));
-		sqsProducer.produce(SlackUserDeleteFeedbackDto.of(request.getComment()));
+		sqsProducer.produce(SlackUserFeedbackDto.of(request.getComment()));
 	}
 }

--- a/hous-api/src/main/java/hous/api/service/user/dto/request/UserFeedbackRequestDto.java
+++ b/hous-api/src/main/java/hous/api/service/user/dto/request/UserFeedbackRequestDto.java
@@ -3,6 +3,8 @@ package hous.api.service.user.dto.request;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import hous.common.constant.Constraint;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AccessLevel;
@@ -24,9 +26,11 @@ public class UserFeedbackRequestDto {
 	@NotBlank(message = "{user.comment.notBlank}")
 	private String comment;
 
-	public static UserFeedbackRequestDto of(String comment) {
-		return UserFeedbackRequestDto.builder()
-			.comment(comment)
-			.build();
+	@ApiModelProperty(value = "회원 탈퇴 여부", example = "false")
+	private boolean isDeleting;
+
+	@JsonProperty("isDeleting")
+	public boolean isDeleting() {
+		return isDeleting;
 	}
 }

--- a/hous-api/src/main/java/hous/api/service/user/dto/request/UserFeedbackRequestDto.java
+++ b/hous-api/src/main/java/hous/api/service/user/dto/request/UserFeedbackRequestDto.java
@@ -17,15 +17,15 @@ import lombok.ToString;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder(access = AccessLevel.PRIVATE)
-public class UserDeleteFeedbackRequestDto {
+public class UserFeedbackRequestDto {
 
 	@ApiModelProperty(value = "의견", example = "흠냐링 제법 괜찮았으나 안쓰게 되네요.")
 	@Size(max = Constraint.FEEDBACK_COMMENT_MAX, message = "{user.comment.max}")
 	@NotBlank(message = "{user.comment.notBlank}")
 	private String comment;
 
-	public static UserDeleteFeedbackRequestDto of(String comment) {
-		return UserDeleteFeedbackRequestDto.builder()
+	public static UserFeedbackRequestDto of(String comment) {
+		return UserFeedbackRequestDto.builder()
 			.comment(comment)
 			.build();
 	}

--- a/hous-api/src/test/java/hous/api/service/badge/BadgeServiceTest.java
+++ b/hous-api/src/test/java/hous/api/service/badge/BadgeServiceTest.java
@@ -366,7 +366,7 @@ public class BadgeServiceTest {
 		roomService.createRoom(setRoomNameRequestDto, userId);
 
 		// when
-		userService.acquireFeedbackBadge(userId);
+		userService.sendUserFeedback(userId);
 
 		// then
 		List<Acquire> acquiresByUser = acquireRepository.findAllAcquireByOnboarding(user.getOnboarding());

--- a/hous-common/src/main/java/hous/common/dto/sqs/SlackUserFeedbackDto.java
+++ b/hous-common/src/main/java/hous/common/dto/sqs/SlackUserFeedbackDto.java
@@ -16,11 +16,13 @@ import lombok.experimental.SuperBuilder;
 public class SlackUserFeedbackDto extends MessageDto {
 
 	private String comment;
+	private Boolean isDeleting;
 
-	public static SlackUserFeedbackDto of(String coment) {
+	public static SlackUserFeedbackDto of(String coment, boolean isDeleting) {
 		return SlackUserFeedbackDto.builder()
 			.type(MessageType.SLACK_USER_DELETE_FEEDBACK)
 			.comment(coment)
+			.isDeleting(isDeleting)
 			.build();
 	}
 }

--- a/hous-common/src/main/java/hous/common/dto/sqs/SlackUserFeedbackDto.java
+++ b/hous-common/src/main/java/hous/common/dto/sqs/SlackUserFeedbackDto.java
@@ -13,12 +13,12 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @SuperBuilder
-public class SlackUserDeleteFeedbackDto extends MessageDto {
+public class SlackUserFeedbackDto extends MessageDto {
 
 	private String comment;
 
-	public static SlackUserDeleteFeedbackDto of(String coment) {
-		return SlackUserDeleteFeedbackDto.builder()
+	public static SlackUserFeedbackDto of(String coment) {
+		return SlackUserFeedbackDto.builder()
 			.type(MessageType.SLACK_USER_DELETE_FEEDBACK)
 			.comment(coment)
 			.build();

--- a/hous-notification/src/main/java/hous/notification/config/sqs/consumer/SqsConsumer.java
+++ b/hous-notification/src/main/java/hous/notification/config/sqs/consumer/SqsConsumer.java
@@ -50,7 +50,8 @@ public class SqsConsumer {
 				case MessageType.SLACK_USER_DELETE_FEEDBACK:
 					SlackUserFeedbackDto slackUserFeedbackDto = objectMapper.readValue(info,
 						SlackUserFeedbackDto.class);
-					slackService.sendSlackMessageUserFeedback(slackUserFeedbackDto.getComment());
+					slackService.sendSlackMessageUserFeedback(
+						slackUserFeedbackDto.getComment(), slackUserFeedbackDto.getIsDeleting());
 			}
 		} catch (Exception exception) {
 			log.error(exception.getMessage(), exception);

--- a/hous-notification/src/main/java/hous/notification/config/sqs/consumer/SqsConsumer.java
+++ b/hous-notification/src/main/java/hous/notification/config/sqs/consumer/SqsConsumer.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import hous.common.constant.MessageType;
 import hous.common.dto.sqs.FirebaseDto;
 import hous.common.dto.sqs.SlackExceptionDto;
-import hous.common.dto.sqs.SlackUserDeleteFeedbackDto;
+import hous.common.dto.sqs.SlackUserFeedbackDto;
 import hous.notification.service.firebase.FirebaseCloudMessageService;
 import hous.notification.service.slack.SlackService;
 import lombok.RequiredArgsConstructor;
@@ -48,9 +48,9 @@ public class SqsConsumer {
 						slackExceptionDto.getInstance(), slackExceptionDto.getException());
 					break;
 				case MessageType.SLACK_USER_DELETE_FEEDBACK:
-					SlackUserDeleteFeedbackDto slackUserDeleteFeedbackDto = objectMapper.readValue(info,
-						SlackUserDeleteFeedbackDto.class);
-					slackService.sendSlackMessageUserDeleteFeedback(slackUserDeleteFeedbackDto.getComment());
+					SlackUserFeedbackDto slackUserFeedbackDto = objectMapper.readValue(info,
+						SlackUserFeedbackDto.class);
+					slackService.sendSlackMessageUserFeedback(slackUserFeedbackDto.getComment());
 			}
 		} catch (Exception exception) {
 			log.error(exception.getMessage(), exception);

--- a/hous-notification/src/main/java/hous/notification/service/slack/SlackService.java
+++ b/hous-notification/src/main/java/hous/notification/service/slack/SlackService.java
@@ -28,7 +28,7 @@ public class SlackService {
 
 	private static final String LOCAL = "local";
 	private static final String PROD_ERROR_MESSAGE_TITLE = "🤯 *500 에러 발생*";
-	private static final String USER_FEEDBACK_TITLE = "🤯 *새로운 사용자 피드백*";
+	private static final String USER_FEEDBACK_TITLE = "📮 *새로운 사용자 피드백*";
 	private static final String ATTACHMENTS_ERROR_COLOR = "#eb4034";
 	private static final String ATTACHMENTS_NOTIFICATION_COLOR = "#36a64f";
 
@@ -49,11 +49,11 @@ public class SlackService {
 		}
 	}
 
-	public void sendSlackMessageUserFeedback(String comment) {
+	public void sendSlackMessageUserFeedback(String comment, boolean isDeleting) {
 		if (!profile.equals(LOCAL)) {
 			try {
 				Slack slack = Slack.getInstance();
-				List<LayoutBlock> layoutBlocks = SlackServiceUtils.createUserFeedbackMessage(comment);
+				List<LayoutBlock> layoutBlocks = SlackServiceUtils.createUserFeedbackMessage(comment, isDeleting);
 				List<Attachment> attachments = SlackServiceUtils.createAttachments(ATTACHMENTS_NOTIFICATION_COLOR,
 					layoutBlocks);
 				slack.methods(token).chatPostMessage(req ->

--- a/hous-notification/src/main/java/hous/notification/service/slack/SlackService.java
+++ b/hous-notification/src/main/java/hous/notification/service/slack/SlackService.java
@@ -23,14 +23,12 @@ public class SlackService {
 	String token;
 	@Value(value = "${slack.channel.monitor}")
 	String channelProductError;
-	@Value(value = "${slack.channel.notification}")
-	String channelDeleteUserNotification;
 	@Value(value = "${slack.channel.feedback}")
-	String channelDeleteUserFeedback;
+	String channelUserFeedback;
 
 	private static final String LOCAL = "local";
 	private static final String PROD_ERROR_MESSAGE_TITLE = "🤯 *500 에러 발생*";
-	private static final String PROD_USER_DELETE_FEEDBACK_TITLE = "🤯 *현재 사용자 탈퇴 피드백*";
+	private static final String USER_FEEDBACK_TITLE = "🤯 *새로운 사용자 피드백*";
 	private static final String ATTACHMENTS_ERROR_COLOR = "#eb4034";
 	private static final String ATTACHMENTS_NOTIFICATION_COLOR = "#36a64f";
 
@@ -51,17 +49,17 @@ public class SlackService {
 		}
 	}
 
-	public void sendSlackMessageUserDeleteFeedback(String comment) {
+	public void sendSlackMessageUserFeedback(String comment) {
 		if (!profile.equals(LOCAL)) {
 			try {
 				Slack slack = Slack.getInstance();
-				List<LayoutBlock> layoutBlocks = SlackServiceUtils.createUserDeleteFeedbackMessage(comment);
+				List<LayoutBlock> layoutBlocks = SlackServiceUtils.createUserFeedbackMessage(comment);
 				List<Attachment> attachments = SlackServiceUtils.createAttachments(ATTACHMENTS_NOTIFICATION_COLOR,
 					layoutBlocks);
 				slack.methods(token).chatPostMessage(req ->
-					req.channel(channelDeleteUserFeedback)
+					req.channel(channelUserFeedback)
 						.attachments(attachments)
-						.text(PROD_USER_DELETE_FEEDBACK_TITLE));
+						.text(USER_FEEDBACK_TITLE));
 			} catch (SlackApiException | IOException e) {
 				log.error(e.getMessage(), e);
 			}

--- a/hous-notification/src/main/java/hous/notification/service/slack/SlackServiceUtils.java
+++ b/hous-notification/src/main/java/hous/notification/service/slack/SlackServiceUtils.java
@@ -42,7 +42,7 @@ public class SlackServiceUtils {
 		return layoutBlockList;
 	}
 
-	public static List<LayoutBlock> createUserDeleteFeedbackMessage(String comment) {
+	public static List<LayoutBlock> createUserFeedbackMessage(String comment) {
 		List<LayoutBlock> layoutBlockList = new ArrayList<>();
 		layoutBlockList.add(section(section -> section.text(markdownText(comment))));
 		return layoutBlockList;

--- a/hous-notification/src/main/java/hous/notification/service/slack/SlackServiceUtils.java
+++ b/hous-notification/src/main/java/hous/notification/service/slack/SlackServiceUtils.java
@@ -16,6 +16,7 @@ public class SlackServiceUtils {
 	private static final String PROD_ERROR_MESSAGE = "*Error Message:*\n";
 	private static final String PROD_ERROR_STACK = "*Error Stack:*\n";
 	private static final String FILTER_STRING = "hous";
+	private static final String USER_DELETE_STATUS = "*Membership Withdrawal:* ";
 
 	public static List<Attachment> createAttachments(String color, List<LayoutBlock> data) {
 		List<Attachment> attachments = new ArrayList<>();
@@ -42,9 +43,15 @@ public class SlackServiceUtils {
 		return layoutBlockList;
 	}
 
-	public static List<LayoutBlock> createUserFeedbackMessage(String comment) {
+	public static List<LayoutBlock> createUserFeedbackMessage(String comment, boolean isDeleting) {
 		List<LayoutBlock> layoutBlockList = new ArrayList<>();
-		layoutBlockList.add(section(section -> section.text(markdownText(comment))));
+
+		List<TextObject> sectionInFields = new ArrayList<>();
+		sectionInFields.add(markdownText(USER_DELETE_STATUS + isDeleting));
+		layoutBlockList.add(section(section -> section.fields(sectionInFields)));
+
+		layoutBlockList.add(divider());
+		layoutBlockList.add(section(section -> section.text(markdownText("```" + comment + "```"))));
 		return layoutBlockList;
 	}
 


### PR DESCRIPTION
## ✒️ 관련 이슈번호

- Closes #351

## 🔑 Key Changes

1. 호미나라 피드백 보내기와, 탈퇴 피드백이 동일한 페이지로 전달되는 걸 깨달아서.. API 를 통합했습니다..
2. 새로 만들었던 회원 탈퇴 피드백 API 를 삭제하고 기존 피드백 API 에서 분기처리해서 동작하도록 수정했습니다!
3. 슬랙 채널명과 알림명, 변수명, 메서드명 전부 수정했어요!


## 📢 To Reviewers
- 사용하지 않는 슬랙 채널 지우고, 피드백 알림 채널 이름 바꿔서 알림 관련 yml 수정있어요! 노션에 반영해뒀습니다!
